### PR TITLE
feat(nest/chain) recursively find max priority of d_elems

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 tests=(
-  priority-change #pass
-  priority-donate-one #pass
-  priority-donate-multiple #pass
+  priority-change           #pass
+  priority-donate-one       #pass
+  priority-donate-multiple  #pass
   priority-donate-multiple2 #pass
-  priority-donate-nest #pass
-  priority-donate-lower #pass
-  priority-donate-chain #pass
-  priority-fifo #pass
-  priority-preempt #pass
-  priority-sema #pass
-  priority-condvar #fail
-  priority-donate-sema #fail
+  priority-donate-nest      #pass
+  priority-donate-lower     #pass
+  priority-donate-chain     #pass
+  priority-fifo             #pass
+  priority-preempt           #pass
+  priority-sema             #pass
+  priority-condvar          #pass
+  priority-donate-sema      #pass
 )
 workspace_root=$(pwd)
 log_dir="$workspace_root/log"

--- a/do.sh
+++ b/do.sh
@@ -4,14 +4,14 @@ tests=(
   priority-donate-one #pass
   priority-donate-multiple #pass
   priority-donate-multiple2 #pass
-  priority-donate-nest #fail
-  priority-donate-sema #fail
+  priority-donate-nest #pass
   priority-donate-lower #pass
-  priority-donate-chain #fail
+  priority-donate-chain #pass
   priority-fifo #pass
   priority-preempt #pass
   priority-sema #pass
-  priority-condvar #fail"
+  priority-condvar #fail
+  priority-donate-sema #fail
 )
 workspace_root=$(pwd)
 log_dir="$workspace_root/log"

--- a/dodebug.sh
+++ b/dodebug.sh
@@ -2,4 +2,4 @@ cd threads
 make clean
 make
 cd build
-pintos --gdb -- -q run priority-donate-one
+pintos --gdb -- -q run priority-donate-nest

--- a/dodebug.sh
+++ b/dodebug.sh
@@ -2,4 +2,4 @@ cd threads
 make clean
 make
 cd build
-pintos --gdb -- -q run priority-donate-nest
+pintos --gdb -- -q run priority-donate-sema

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -159,7 +159,10 @@ struct thread *get_thread_d_elem(const struct list_elem *elem);
 int get_priority(struct thread *target);
 
 bool tick_ascend(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
-bool priority_desc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+bool priority_dsc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+bool priority_asc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+bool priority_dsc_d(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+bool priority_asc_d(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 bool origin_priority_asc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 bool origin_priority_dsc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
 bool origin_priority_asc_d(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -66,7 +66,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_insert_ordered(&sema->waiters, &thread_current ()->elem, origin_priority_dsc, NULL);
+		list_push_back(&sema->waiters, &thread_current ()->elem);
 		thread_block ();
 	}
 	sema->value--;
@@ -109,9 +109,12 @@ sema_up (struct semaphore *sema) {
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+	if (!list_empty (&sema->waiters)) {
+		struct list_elem *max_e = list_max(&sema->waiters, priority_asc, NULL);
+		struct thread *max_t = get_thread_elem(max_e);
+		list_remove(max_e);
+		thread_unblock(max_t);
+	}
 	
 	sema->value++;
 	thread_yield(); // ready list 재정렬 후 강제 yield
@@ -257,16 +260,6 @@ lock_release (struct lock *lock) {
 		list_remove(&waiter_max_t->d_elem);
 	}
 
-	// unblock된 thread의 priority가 획득할 lock의 waiters 중 max_priority보다 작은 경우
-	// max priority를 가진 thread의 d_elem을 donation_list에 추가한다
-	if (!list_empty(waiters)) {
-		struct thread *soon_unblock = get_thread_elem(list_front(waiters));
-		if (soon_unblock->priority < waiter_max_t->priority) {
-			// d_list에 추가하기 때문에 `d_elem`을 가리킨다.
-			list_push_back(&soon_unblock->donation_list, &waiter_max_t->d_elem);
-		}
-	}
-
 	lock->holder = NULL;
 	sema_up (&lock->semaphore);
 }
@@ -283,9 +276,21 @@ lock_held_by_current_thread (const struct lock *lock) {
 
 /* One semaphore in a list. */
 struct semaphore_elem {
+	struct thread *ptr_th;				/* pointer of current thread */
 	struct list_elem elem;              /* List element. */
 	struct semaphore semaphore;         /* This semaphore. */
 };
+
+static inline bool priority_asc_semaelem(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+	struct semaphore_elem	*a_semaelem = list_entry(a, struct semaphore_elem, elem);
+	struct semaphore_elem	*b_semaelem = list_entry(b, struct semaphore_elem, elem);
+	
+	return get_priority(a_semaelem->ptr_th) < get_priority(b_semaelem->ptr_th);
+}
+
+static inline bool priority_dsc_semaelem(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+	return !priority_asc_semaelem(a, b, aux);
+}
 
 /* Initializes condition variable COND.  A condition variable
    allows one piece of code to signal a condition and cooperating
@@ -327,6 +332,9 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	sema_init (&waiter.semaphore, 0);
+	waiter.ptr_th = thread_current();
+
+	// 깡통 semaphore_elem 타입을 정렬하기 위해서 구조체를 확장해야만 했습니다.
 	list_push_back (&cond->waiters, &waiter.elem);
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
@@ -347,9 +355,11 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
-	if (!list_empty (&cond->waiters))
-		sema_up (&list_entry (list_pop_front (&cond->waiters),
-					struct semaphore_elem, elem)->semaphore);
+	if (!list_empty (&cond->waiters)) {
+		struct list_elem *max_elem = list_max(&cond->waiters, priority_asc_semaelem, NULL);
+		list_remove(max_elem);
+		sema_up (&list_entry (max_elem, struct semaphore_elem, elem)->semaphore);
+	}
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -536,6 +536,9 @@ struct thread *get_thread_d_elem(const struct list_elem *e) {
   return list_entry(e, struct thread, d_elem);
 }
 
+/**
+ * @brief Get the donated priority RECURSIVELY
+ */
 int get_priority(struct thread *target) {
   if (list_empty(&target->donation_list)) {
     // original priority
@@ -557,6 +560,9 @@ bool priority_dsc(const struct list_elem *a, const struct list_elem *b, void *au
   return get_priority(a_th) > get_priority(b_th);
 }
 
+/**
+ * @brief donate_list에 priority 오름차순 정렬
+ */
 bool priority_asc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
   return !priority_dsc(a, b, aux);
 }

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -257,7 +257,7 @@ thread_unblock (struct thread *t) {
 
   old_level = intr_disable ();
   ASSERT (t->status == THREAD_BLOCKED);
-  list_insert_ordered(&ready_list, &t->elem, priority_desc, NULL);
+  list_insert_ordered(&ready_list, &t->elem, priority_dsc, NULL);
   t->status = THREAD_READY;
   intr_set_level (old_level);
 }
@@ -320,7 +320,7 @@ thread_yield (void) {
 
   old_level = intr_disable ();
   if (curr != idle_thread)
-    list_insert_ordered(&ready_list, &curr->elem, priority_desc, NULL);
+    list_insert_ordered(&ready_list, &curr->elem, priority_dsc, NULL);
   do_schedule (THREAD_READY);
   intr_set_level (old_level);
 }
@@ -542,19 +542,34 @@ int get_priority(struct thread *target) {
     return target->priority;
   }
   // not empty list
-  struct list_elem *max_elem = list_max(&target->donation_list, origin_priority_asc_d, NULL);
+  struct list_elem *max_elem = list_max(&target->donation_list, priority_asc_d, NULL);
 
-  return get_thread_d_elem(max_elem)->priority;
+  return get_priority(get_thread_d_elem(max_elem));
 }
 
 /**
  * @brief ready list에 priority 내림차순 정렬
  */
-bool priority_desc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+bool priority_dsc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
   struct thread *a_th = list_entry(a, struct thread, elem);
   struct thread *b_th = list_entry(b, struct thread, elem);
   
   return get_priority(a_th) > get_priority(b_th);
+}
+
+bool priority_asc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+  return !priority_dsc(a, b, aux);
+}
+
+bool priority_dsc_d(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+  struct thread *a_th = get_thread_d_elem(a);
+  struct thread *b_th = get_thread_d_elem(b);
+  
+  return get_priority(a_th) > get_priority(b_th);
+}
+
+bool priority_asc_d(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+  return !priority_dsc_d(a, b, aux);
 }
 
 bool origin_priority_asc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED){


### PR DESCRIPTION
## update

`get_priority` 부분 리턴할 때 기존에는 origin priority를 리턴하였으나, 재귀적으로 호출하여 donate list의 최대 priority 스레드의 `get_priority`를 리턴하도록 만들었습니다.

## pass

-   priority-change #pass
-   priority-donate-one #pass
-   priority-donate-multiple #pass
-   priority-donate-multiple2 #pass
-   priority-donate-nest #pass
-   priority-donate-lower #pass
-   priority-donate-chain #pass
-   priority-fifo #pass
-   priority-preempt #pass
-   priority-sema #pass

## fail

[vscode Diff](https://marketplace.visualstudio.com/items?itemName=fabiospampinato.vscode-diff) 플러그인으로 확인했습니다. 정답파일 <-- 로그파일 방향으로 diff를 진행했으며, 붉은색이 정답파일에만 있는 부분, 초록색이 로그파일에만 있는 부분, 하얀색이 일치하는 부분을 의미합니다.

-   priority-condvar #fail

<img width="366" alt="스크린샷 2023-09-29 오후 6 13 56" src="https://github.com/ChoiWheatley/swjungle-week07-09/assets/18757823/f420b6ec-c4a9-477c-81fc-3152811b74e2">


-   priority-donate-sema #fail

<img width="482" alt="스크린샷 2023-09-29 오후 6 11 54" src="https://github.com/ChoiWheatley/swjungle-week07-09/assets/18757823/a9576670-daef-4999-b430-1c58bb5625aa">
