### PR TITLE
feat(donate-sema) sema_up now always pops max elem

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -11,7 +11,7 @@ tests=(
   priority-preempt #pass
   priority-sema #pass
   priority-condvar #fail
-  priority-donate-sema #fail
+  priority-donate-sema #pass
 )
 workspace_root=$(pwd)
 log_dir="$workspace_root/log"

--- a/dodebug.sh
+++ b/dodebug.sh
@@ -2,4 +2,4 @@ cd threads
 make clean
 make
 cd build
-pintos --gdb -- -q run priority-donate-nest
+pintos --gdb -- -q run priority-donate-sema

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -109,9 +109,12 @@ sema_up (struct semaphore *sema) {
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+	if (!list_empty (&sema->waiters)) {
+		struct list_elem *max_e = list_max(&sema->waiters, priority_asc, NULL);
+		struct thread *max_t = get_thread_elem(max_e);
+		list_remove(max_e);
+		thread_unblock(max_t);
+	}
 	
 	sema->value++;
 	thread_yield(); // ready list 재정렬 후 강제 yield

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -536,6 +536,9 @@ struct thread *get_thread_d_elem(const struct list_elem *e) {
   return list_entry(e, struct thread, d_elem);
 }
 
+/**
+ * @brief Get the donated priority RECURSIVELY
+ */
 int get_priority(struct thread *target) {
   if (list_empty(&target->donation_list)) {
     // original priority
@@ -557,6 +560,9 @@ bool priority_dsc(const struct list_elem *a, const struct list_elem *b, void *au
   return get_priority(a_th) > get_priority(b_th);
 }
 
+/**
+ * @brief donate_list에 priority 오름차순 정렬
+ */
 bool priority_asc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
   return !priority_dsc(a, b, aux);
 }


### PR DESCRIPTION
## update

`sema_up` 에서 pop front 하던 코드를 max `d_elem`을 선별하여 제거하도록 바꾸었습니다. 분명히 `sema_down`에서 정렬하여 넣었음에도, 나중에 기부받은 건에 대해서는 정렬상태를 보장해주지 않더군요. `lock_acquire`할 때 lock 획득에 실패한 경우 waiters를 다시 정렬해 주는 것이 좋을지 모르겠습니다.

## pass

- priority-donate-sema

## fail

- priority-condvar