### PR TITLE
feat(test-priority-condvar) accept

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 tests=(
-  priority-change #pass
-  priority-donate-one #pass
-  priority-donate-multiple #pass
+  priority-change           #pass
+  priority-donate-one       #pass
+  priority-donate-multiple  #pass
   priority-donate-multiple2 #pass
-  priority-donate-nest #pass
-  priority-donate-lower #pass
-  priority-donate-chain #pass
-  priority-fifo #pass
-  priority-preempt #pass
-  priority-sema #pass
-  priority-condvar #fail
-  priority-donate-sema #pass
+  priority-donate-nest      #pass
+  priority-donate-lower     #pass
+  priority-donate-chain     #pass
+  priority-fifo             #pass
+  priority-preempt           #pass
+  priority-sema             #pass
+  priority-condvar          #pass
+  priority-donate-sema      #pass
 )
 workspace_root=$(pwd)
 log_dir="$workspace_root/log"

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -66,7 +66,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_insert_ordered(&sema->waiters, &thread_current ()->elem, origin_priority_dsc, NULL);
+		list_push_back(&sema->waiters, &thread_current ()->elem);
 		thread_block ();
 	}
 	sema->value--;
@@ -258,16 +258,6 @@ lock_release (struct lock *lock) {
 	if (lock_holder->priority < waiter_max_t->priority) {
 		// donate_list에 원소가 존재하는 경우 
 		list_remove(&waiter_max_t->d_elem);
-	}
-
-	// unblock된 thread의 priority가 획득할 lock의 waiters 중 max_priority보다 작은 경우
-	// max priority를 가진 thread의 d_elem을 donation_list에 추가한다
-	if (!list_empty(waiters)) {
-		struct thread *soon_unblock = get_thread_elem(list_front(waiters));
-		if (soon_unblock->priority < waiter_max_t->priority) {
-			// d_list에 추가하기 때문에 `d_elem`을 가리킨다.
-			list_push_back(&soon_unblock->donation_list, &waiter_max_t->d_elem);
-		}
 	}
 
 	lock->holder = NULL;


### PR DESCRIPTION
## update

깡통타입 `semaphore_elem`을 확장할 수밖에 없었습니다. condvar의 기존 취지와는 다르게 높은 우선순위를 기준으로 정렬이 들어가야만 했기 때문이죠.

## pass

- all tests