### PR TITLE
feat(fork, wait, exit)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,8 @@
         "*.inc": "c",
         "gdt.h": "c",
         "intrinsic.h": "c",
-        "syscall.h": "c"
+        "syscall.h": "c",
+        "file.h": "c",
+        "synch.h": "c"
     }
 }

--- a/do.sh
+++ b/do.sh
@@ -33,9 +33,10 @@ cd userprog
 make clean
 make -j $(nproc --all)
 cd build
-# pintos-mkdisk filesys.dsk 10
+pintos-mkdisk filesys.dsk 10
 # pintos --fs-disk filesys.dsk -p tests/userprog/args-single:args-single -- -q -f run 'args-single onearg'
 # pintos --fs-disk filesys.dsk -p tests/userprog/args-single:args-single -- -f run 'args-single onearg'
+pintos --fs-disk filesys.dsk -p tests/userprog/fork-once:fork-once --gdb -- -f run 'fork-once'
 # pintos --fs-disk -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt -- -q -f run read-normal
-pintos --fs-disk=10 -p tests/userprog/close-normal:close-normal -p ../../tests/userprog/sample.txt:sample.txt --gdb -- -q -f  run 'close-normal'
+# pintos --fs-disk=10 -p tests/userprog/close-normal:close-normal -p ../../tests/userprog/sample.txt:sample.txt --gdb -- -q -f  run 'close-normal'
 

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -138,6 +138,7 @@ struct thread {
 
   /* Owned by thread.c. */
   struct intr_frame tf; /* Information for switching */
+  struct intr_frame bf;
   unsigned magic;       /* Detects stack overflow. */
 };
 

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -29,8 +29,8 @@ typedef int32_t fixed_point;
 
 struct child_info {
 	tid_t pid;
-	int exit_status;
-	bool exited;
+	int exit_status; // parent process_wait의 반환값
+	bool exited; // exit(비정상 종료 포함)될때 true
 };
 
 #define TID_ERROR ((tid_t) -1)          /* Error value for tid_t. */
@@ -122,7 +122,7 @@ struct thread {
 
 	uint64_t *pml4;                     /* Page map level 4 */
 	struct file **fd_table;					/* file descriptor table */
-	// struct list child_list;
+	struct list child_list;
 	struct thread *parent;
 	struct semaphore wait_sema;					
 	struct semaphore fork_sema;

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -31,6 +31,8 @@ struct child_info {
 	tid_t pid;
 	int exit_status; // parent process_wait의 반환값
 	bool exited; // exit(비정상 종료 포함)될때 true
+	
+	struct list_elem c_elem;
 };
 
 #define TID_ERROR ((tid_t) -1)          /* Error value for tid_t. */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -5,19 +5,18 @@
 #include <list.h>
 #include <stdint.h>
 
-#include "threads/synch.h"
 #include "threads/interrupt.h"
+#include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
 
-
 /* States in a thread's life cycle. */
 enum thread_status {
-	THREAD_RUNNING,     /* Running thread. */
-	THREAD_READY,       /* Not running but ready to run. */
-	THREAD_BLOCKED,     /* Waiting for an event to trigger. */
-	THREAD_DYING        /* About to be destroyed. */
+  THREAD_RUNNING, /* Running thread. */
+  THREAD_READY,   /* Not running but ready to run. */
+  THREAD_BLOCKED, /* Waiting for an event to trigger. */
+  THREAD_DYING    /* About to be destroyed. */
 };
 
 /* Thread identifier type.
@@ -28,19 +27,20 @@ typedef int tid_t;
 typedef int32_t fixed_point;
 
 struct child_info {
-	tid_t pid;
-	int exit_status; // parent process_wait의 반환값
-	bool exited; // exit(비정상 종료 포함)될때 true
-	
-	struct list_elem c_elem;
+  tid_t pid;
+  struct thread *th;
+  int exit_status; // parent process_wait의 반환값
+  bool exited;     // exit(비정상 종료 포함)될때 true
+
+  struct list_elem c_elem;
 };
 
-#define TID_ERROR ((tid_t) -1)          /* Error value for tid_t. */
+#define TID_ERROR ((tid_t)-1) /* Error value for tid_t. */
 
 /* Thread priorities. */
-#define PRI_MIN 0                       /* Lowest priority. */
-#define PRI_DEFAULT 31                  /* Default priority. */
-#define PRI_MAX 63                      /* Highest priority. */
+#define PRI_MIN 0      /* Lowest priority. */
+#define PRI_DEFAULT 31 /* Default priority. */
+#define PRI_MAX 63     /* Highest priority. */
 
 /* A kernel thread or user process.
  *
@@ -100,45 +100,45 @@ struct child_info {
  * ready state is on the run queue, whereas only a thread in the
  * blocked state is on a semaphore wait list. */
 struct thread {
-	/* Owned by thread.c. */
-	tid_t tid;                          /* Thread identifier. */
-	enum thread_status status;          /* Thread state. */
-	char name[16];                      /* Name (for debugging purposes). */
-	int priority;                       /* Priority. */
-	
-	int64_t local_tick; 				/* `timer_sleep`에서 저장할 로컬 틱 */
-	struct lock *wait_on_lock;			/* 내가 기다리고 있는 lock */
-	
-	/* Shared between thread.c and synch.c. */
-	struct list_elem elem;              /* List element used for ready list OR waiters list */
-	
-	struct list donation_list;			/* 내가 가진 lock들의 waiter들 중 최대 priority를 가진 스레드들의 d_elem 연결리스트*/
-	struct list_elem d_elem; 			/* donation 리스트의 원소 */
+  /* Owned by thread.c. */
+  tid_t tid;                 /* Thread identifier. */
+  enum thread_status status; /* Thread state. */
+  char name[16];             /* Name (for debugging purposes). */
+  int priority;              /* Priority. */
 
-	int nice;                           /* 다른 스레드에게 얼마나 CPU time을 퍼줄 것인지 */
-  	fixed_point recent_cpu;             /* 스레드가 CPU time을 얼마나 점유하고 있는지 */
+  int64_t local_tick;        /* `timer_sleep`에서 저장할 로컬 틱 */
+  struct lock *wait_on_lock; /* 내가 기다리고 있는 lock */
+
+  /* Shared between thread.c and synch.c. */
+  struct list_elem elem; /* List element used for ready list OR waiters list */
+
+  struct list donation_list; /* 내가 가진 lock들의 waiter들 중 최대 priority를
+                                가진 스레드들의 d_elem 연결리스트*/
+  struct list_elem d_elem; /* donation 리스트의 원소 */
+
+  int nice; /* 다른 스레드에게 얼마나 CPU time을 퍼줄 것인지 */
+  fixed_point recent_cpu; /* 스레드가 CPU time을 얼마나 점유하고 있는지 */
 #ifdef USERPROG
-	/* Owned by userprog/process.c. */
-	int exit_status;					/* exit 했는지 확인하기 위한 status */
-	int fd_idx;
+  /* Owned by userprog/process.c. */
+  int exit_status; /* exit 했는지 확인하기 위한 status */
+  int fd_idx;
 
-	uint64_t *pml4;                     /* Page map level 4 */
-	struct file **fd_table;					/* file descriptor table */
-	struct list child_list;
-	struct thread *parent;
-	struct semaphore wait_sema;					
-	struct semaphore fork_sema;
-	struct semaphore exit_sema;
+  uint64_t *pml4;         /* Page map level 4 */
+  struct file **fd_table; /* file descriptor table */
+  struct list child_list;
+  struct thread *parent;
+  struct semaphore wait_sema;
+  struct semaphore fork_sema;
+  // struct semaphore exit_sema;
 #endif
 #ifdef VM
-	/* Table for whole virtual memory owned by thread. */
-	struct supplemental_page_table spt;
+  /* Table for whole virtual memory owned by thread. */
+  struct supplemental_page_table spt;
 #endif
 
-
-	/* Owned by thread.c. */
-	struct intr_frame tf;               /* Information for switching */
-	unsigned magic;                     /* Detects stack overflow. */
+  /* Owned by thread.c. */
+  struct intr_frame tf; /* Information for switching */
+  unsigned magic;       /* Detects stack overflow. */
 };
 
 /* If false (default), use round-robin scheduler.
@@ -146,38 +146,39 @@ struct thread {
    Controlled by kernel command-line option "-o mlfqs". */
 extern bool thread_mlfqs;
 
-void thread_init (void);
-void thread_start (void);
+void thread_init(void);
+void thread_start(void);
 
-void thread_tick (void);
-void thread_print_stats (void);
+void thread_tick(void);
+void thread_print_stats(void);
 
-typedef void thread_func (void *aux);
-tid_t thread_create (const char *name, int priority, thread_func *, void *);
+typedef void thread_func(void *aux);
+tid_t thread_create(const char *name, int priority, thread_func *, void *);
 
-void thread_block (void);
-void thread_unblock (struct thread *);
+void thread_block(void);
+void thread_unblock(struct thread *);
 
-struct thread *thread_current (void);
-tid_t thread_tid (void);
-const char *thread_name (void);
+struct thread *thread_current(void);
+tid_t thread_tid(void);
+const char *thread_name(void);
 
-void thread_exit (void) NO_RETURN;
-void thread_yield (void);
+void thread_exit(void) NO_RETURN;
+void thread_yield(void);
 
-int thread_get_priority (void);
-void thread_set_priority (int);
+int thread_get_priority(void);
+void thread_set_priority(int);
 
-int thread_get_nice (void);
-void thread_set_nice (int);
-int thread_get_recent_cpu (void);
-int thread_get_load_avg (void);
+int thread_get_nice(void);
+void thread_set_nice(int);
+int thread_get_recent_cpu(void);
+int thread_get_load_avg(void);
 
-void do_iret (struct intr_frame *tf);
+void do_iret(struct intr_frame *tf);
 
 /** SECTION - Additional Decl */
 void thread_sleep(int64_t ticks);
-void thread_wakeup(); // sleep_list에서 자기 차례가 되면 ready_list로 unblock해서 list_push_back 함수
+void thread_wakeup(); // sleep_list에서 자기 차례가 되면 ready_list로
+                      // unblock해서 list_push_back 함수
 void update_priority();
 
 struct thread *get_thread_elem(const struct list_elem *elem);
@@ -192,15 +193,24 @@ void update_load_avg();
 
 void set_priority_mlfqs(struct thread *target);
 
-bool tick_ascend(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
-bool priority_dsc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
-bool priority_asc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
-bool priority_dsc_d(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
-bool priority_asc_d(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
-bool origin_priority_dsc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
-bool origin_priority_asc(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
-bool origin_priority_dsc_d(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
-bool origin_priority_asc_d(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+bool tick_ascend(const struct list_elem *a, const struct list_elem *b,
+                 void *aux UNUSED);
+bool priority_dsc(const struct list_elem *a, const struct list_elem *b,
+                  void *aux UNUSED);
+bool priority_asc(const struct list_elem *a, const struct list_elem *b,
+                  void *aux UNUSED);
+bool priority_dsc_d(const struct list_elem *a, const struct list_elem *b,
+                    void *aux UNUSED);
+bool priority_asc_d(const struct list_elem *a, const struct list_elem *b,
+                    void *aux UNUSED);
+bool origin_priority_dsc(const struct list_elem *a, const struct list_elem *b,
+                         void *aux UNUSED);
+bool origin_priority_asc(const struct list_elem *a, const struct list_elem *b,
+                         void *aux UNUSED);
+bool origin_priority_dsc_d(const struct list_elem *a, const struct list_elem *b,
+                           void *aux UNUSED);
+bool origin_priority_asc_d(const struct list_elem *a, const struct list_elem *b,
+                           void *aux UNUSED);
 /** !SECTION - Additional Decl */
 
 /** SECTION - Fixed Point Arithmetic Operations */
@@ -210,7 +220,7 @@ bool origin_priority_asc_d(const struct list_elem *a, const struct list_elem *b,
 #define F (1 << Q)
 #define FIXED_POINT(n) ((n) * (F))
 #define INT32_T(x) ((x) / (F))
-#define INT32_T_RND(x) \
+#define INT32_T_RND(x)                                                         \
   ((x) >= 0) ? ((x) + (F) / 2) / (F) : ((x) - (F) / 2) / (F)
 #define FXP_ADD(x, y) ((x) + (y))
 #define FXP_ADD_INT(x, n) ((x) + FIXED_POINT(n))
@@ -221,22 +231,22 @@ bool origin_priority_asc_d(const struct list_elem *a, const struct list_elem *b,
 #define FXP_DIV(x, y) (fixed_point)(((int64_t)(x)) * F / (y))
 #define FXP_DIV_INT(x, n) ((x) / (n))
 
-fixed_point to_fixed_point(int32_t n); 
-int32_t to_int32_t(fixed_point x); 
-int32_t to_int32_t_rnd(fixed_point x); 
-fixed_point add(fixed_point x, fixed_point y); 
-fixed_point add_int(fixed_point x, int32_t n); 
-fixed_point sub(fixed_point x, fixed_point y); 
-fixed_point sub_int(fixed_point x, int32_t n); 
-fixed_point mul(fixed_point x, fixed_point y); 
-fixed_point mul_int(fixed_point x, int32_t n); 
-fixed_point div(fixed_point x, fixed_point y); 
-fixed_point div_int(fixed_point x, int32_t n); 
+fixed_point to_fixed_point(int32_t n);
+int32_t to_int32_t(fixed_point x);
+int32_t to_int32_t_rnd(fixed_point x);
+fixed_point add(fixed_point x, fixed_point y);
+fixed_point add_int(fixed_point x, int32_t n);
+fixed_point sub(fixed_point x, fixed_point y);
+fixed_point sub_int(fixed_point x, int32_t n);
+fixed_point mul(fixed_point x, fixed_point y);
+fixed_point mul_int(fixed_point x, int32_t n);
+fixed_point div(fixed_point x, fixed_point y);
+fixed_point div_int(fixed_point x, int32_t n);
 /** !SECTION - Fixed Point Arithmetic Operations */
 
 /* SECTION - USER PROGRAM */
 #define FDT_PAGES 3
-#define FDCOUNT_LIMIT FDT_PAGES *(1<<9)
+#define FDCOUNT_LIMIT FDT_PAGES * (1 << 9)
 /* !SECTION - USER PROGRAM */
 
 #endif /* threads/thread.h */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -138,7 +138,7 @@ struct thread {
 
   /* Owned by thread.c. */
   struct intr_frame tf; /* Information for switching */
-  struct intr_frame bf;
+  struct intr_frame bf; /* interrrupt frame backup (user-level 정보) */
   unsigned magic;       /* Detects stack overflow. */
 };
 

--- a/include/userprog/syscall.h
+++ b/include/userprog/syscall.h
@@ -2,4 +2,5 @@
 #define USERPROG_SYSCALL_H
 
 void syscall_init(void);
+
 #endif /* userprog/syscall.h */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -210,7 +210,7 @@ thread_print_stats (void) {
 tid_t
 thread_create (const char *name, int priority,
     thread_func *function, void *aux) {
-  struct thread *t;
+  struct thread *t, *cur = thread_current();
   tid_t tid;
 
   ASSERT (function != NULL);
@@ -249,7 +249,7 @@ thread_create (const char *name, int priority,
   t->fd_table[0] = 1;   // stdin 자리 : 1 배정
   t->fd_table[1] = 2;   // stdout 자리 : 2 배정
   t->parent = thread_current();
-  list_push_front(&t->parent->child_list, &ch_info->c_elem);
+  list_push_front(&cur->child_list, &ch_info->c_elem);
 #endif  /* USERPROG */
 
   /* Add to run queue. */
@@ -456,7 +456,9 @@ idle (void *idle_started_ UNUSED) {
     g_ready_threads -= 1;
     list_remove(&idle_thread->d_elem);
   }
+#ifdef USERPROG
 
+#endif // USERPROG
   sema_up (idle_started);
 
   for (;;) {

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -236,6 +236,11 @@ thread_create (const char *name, int priority,
   t->tf.eflags = FLAG_IF;
 
 #ifdef USERPROG
+  struct child_info *ch_info = (struct child_info *) malloc(sizeof(struct child_info));
+  ch_info->pid = tid;
+  ch_info->th = t;
+  ch_info->exited = false;
+
   t->fd_table = palloc_get_multiple(PAL_ZERO, FDT_PAGES);
   if (t->fd_table == NULL) {
     return TID_ERROR;
@@ -243,6 +248,8 @@ thread_create (const char *name, int priority,
   t->fd_idx = 2;
   t->fd_table[0] = 1;   // stdin 자리 : 1 배정
   t->fd_table[1] = 2;   // stdout 자리 : 2 배정
+  t->parent = thread_current();
+  list_push_front(&t->parent->child_list, &ch_info->c_elem);
 #endif  /* USERPROG */
 
   /* Add to run queue. */
@@ -515,9 +522,9 @@ init_thread (struct thread *t, const char *name, int priority) {
 
 #ifdef USERPROG
   t->exit_status = 0;
+  list_init(&t->child_list);
   sema_init(&t->wait_sema, 0);
   sema_init(&t->fork_sema, 0);
-  sema_init(&t->exit_sema, 0);
 #endif
 }
 

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -515,6 +515,9 @@ init_thread (struct thread *t, const char *name, int priority) {
 
 #ifdef USERPROG
   t->exit_status = 0;
+  sema_init(&t->wait_sema, 0);
+  sema_init(&t->fork_sema, 0);
+  sema_init(&t->exit_sema, 0);
 #endif
 }
 

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -7,7 +7,7 @@
 #include "intrinsic.h"
 
 // #include "tests/threads/tests.h" // debug
-#include "userprog/syscall.h"
+// #include "userprog/syscall.h"
 
 /* Number of page faults processed. */
 static long long page_fault_cnt;
@@ -198,21 +198,4 @@ put_user (uint8_t *udst, uint8_t byte) {
     "done_put:\n"
     : "=&a" (error_code), "=m" (*udst) : "q" (byte));
     return error_code != -1;
-}
-
-/**
- * @brief 사용자 주소가 유효한지 여부를 판단한다. 두 가지 검사를 수행한다.
- * 1. 주소값이 KERN_BASE보다 크다면 커널주소를 참조하려고 하기 때문에 page
- * fault를 발생시켜 프로세스를 종료시켜야 한다.
- * 2. 할당이 안된 영역을 참조하려고 한다면 segfault를 발생시켜 프로세스를
- * 종료시켜야 한다.
- *
- * @param uaddr 유저 프로그램이 syscall을 통해 요청한 주소
- * @return 주소가 유효한지 여부
- * @note 해당 함수는 유저 프로그램을 종료시켜줍니다.
- */
-void check_address(const void *uaddr) {
-  if (is_kernel_vaddr(uaddr) || pml4_get_page(thread_current()->pml4, uaddr) == NULL) {
-		exit(-1);
-  } 
 }

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -247,6 +247,7 @@ int process_wait(tid_t child_tid UNUSED) {
     }
 
     int child_status = list_entry(e, struct child_info, c_elem)->exit_status;
+    list_remove(e);
     return child_status;
   }else{
     return -1;

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -226,11 +226,37 @@ int process_exec(void *f_name) {
  * This function will be implemented in problem 2-2.  For now, it
  * does nothing. */
 int process_wait(tid_t child_tid UNUSED) {
-  thread_sleep(150);
+  // thread_sleep(150);
+  // TODO - child_list를 순회. pid 없으면 -1 리턴, 있다면 exited 여부 & exit_status 검사
+  struct thread *curr = thread_current();
+  struct list c_list = curr->child_list;
+  struct list_elem *e;
+  bool is_child = false;
+  if (!list_empty(&c_list)){
+    for (e= list_begin(&c_list); e != list_end(&c_list); e = list_next(e))
+      if (child_tid == list_entry(e, struct child_info, c_elem)->pid) {
+        is_child = true;
+        break;
+      }
+  }
+  if(is_child ){
+    bool exited = list_entry(e, struct child_info, c_elem)->exited;
+    if (exited == 0){
+      sema_init(&curr->wait_sema, 0);
+      sema_down(&curr->wait_sema);
+    }
+
+    int child_status = list_entry(e, struct child_info, c_elem)->exit_status;
+    return child_status;
+  }else{
+    return -1;
+  }
+  
+
   /* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
    * XXX:       to add infinite loop here before
    * XXX:       implementing the process_wait. */
-  // TODO - child_list를 순회. pid 없으면 -1 리턴, 있다면 exited 여부 & exit_status 검사
+  
   /**
    * cases: 
    * - 자식이 살아있는 경우) sema_down until child process die with `exit`
@@ -241,7 +267,6 @@ int process_wait(tid_t child_tid UNUSED) {
    * semaphore를 낮춘다. 이때 semaphore의 값을 0으로 바꿔주어야 한다.
    */
   // sema_down(&thread_current()->wait_sema);
-  return -1;
 }
 
 /* Exit the process. This function is called by thread_exit (). */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -1,5 +1,4 @@
 #include "userprog/process.h"
-#include "userprog/exception.h"
 #include "filesys/directory.h"
 #include "filesys/file.h"
 #include "filesys/filesys.h"
@@ -12,6 +11,7 @@
 #include "threads/palloc.h"
 #include "threads/thread.h"
 #include "threads/vaddr.h"
+#include "userprog/exception.h"
 #include "userprog/gdt.h"
 #include "userprog/tss.h"
 #include <debug.h>
@@ -75,8 +75,34 @@ static void initd(void *f_name) {
 /* Clones the current process as `name`. Returns the new process's thread id, or
  * TID_ERROR if the thread cannot be created. */
 tid_t process_fork(const char *name, struct intr_frame *if_ UNUSED) {
+  // TODO - do wait until child process done fork
+  struct thread *cur = thread_current();
+  struct list_elem *e;
+  struct list *c_list = &cur->child_list;
+  struct thread *child_th;
+  struct child_info *ch_info;
+
   /* Clone current thread to new thread.*/
-  return thread_create(name, PRI_DEFAULT, __do_fork, thread_current());
+  tid_t tid = thread_create(name, PRI_DEFAULT, __do_fork, thread_current());
+  if (tid == TID_ERROR) {
+    return TID_ERROR;
+  }
+  // cur(부모)의 child_list에 위에서 create한 자식의 child_info의 c_elem이 들어가있다.
+  // 방금 추가된 child_info를 tid로 찾는다.
+  // 찾은 tid로 방금 생성된 thread를 찾는다.
+  // 방금 생성된 thread의 fork_sema를 sema_down한다.
+  for (e = list_begin(&c_list); e != list_end(&c_list); e = list_next(e)) {
+    ch_info = list_entry(e, struct child_info, c_elem);  // 자식의 유서
+    if (tid == ch_info->pid) {  // 기다리려는 자식이 맞다면
+      child_th = ch_info->th;  // 자식의 thread// 내 자식이 맞다!
+      sema_down(&child_th->fork_sema);
+      break;
+    }
+  }
+  if (child_th->exit_status == -1) {
+    return TID_ERROR;
+  }
+  return tid;
 }
 
 #ifndef VM
@@ -90,29 +116,41 @@ static bool duplicate_pte(uint64_t *pte, void *va, void *aux) {
   bool writable;
 
   /* 1. TODO: If the parent_page is kernel page, then return immediately. */
+  if (is_kernel_vaddr(va)) {
+    return false;
+  }
 
   /* 2. Resolve VA from the parent's page map level 4. */
   parent_page = pml4_get_page(parent->pml4, va);
+  if (parent_page == NULL) {
+    return false;
+  }
 
   /* 3. TODO: Allocate new PAL_USER page for the child and set result to
-   *    TODO: NEWPAGE. 
+   *    TODO: NEWPAGE.
    * 유저 페이지 할당
    */
+  newpage = palloc_get_page(PAL_ZERO | PAL_USER);
+  if (newpage == NULL) {
+    return false;
+  }
 
   /* 4. TODO: Duplicate parent's page to the new page and
    *    TODO: check whether parent's page is writable or not (set WRITABLE
-   *    TODO: according to the result). 
+   *    TODO: according to the result).
    * 기존 페이지를 새 페이지에 복제한다.
    * */
-
+  memcpy(newpage, parent_page, PGSIZE);
+  writable = is_writable(pte);
   /* 5. Add new page to child's page table at address VA with WRITABLE
-   *    permission. 
+   *    permission.
    * 페이지에 권한부여
    */
   if (!pml4_set_page(current->pml4, va, newpage, writable)) {
-    /* 6. TODO: if fail to insert page, do error handling. 
+    /* 6. TODO: if fail to insert page, do error handling.
      * 에러 핸들링
-    */
+     */
+    return false;
   }
   return true;
 }
@@ -123,9 +161,9 @@ static bool duplicate_pte(uint64_t *pte, void *va, void *aux) {
  * @note - parent->tf does not hold the userland context of the process.
  *       That is, you are required to pass second argument of process_fork to
  *       this function.
- * @note - process_exec과의 유일한 차이점은 parent의 컨텍스트와 file, lock, page를
- * 몽땅 복사한다는 점이다. Project 3 Virtual Memory에서 Copy On Write를 하기
- * 전까지는 모든 내용을 복제하는 것으로 보인다.
+ * @note - process_exec과의 유일한 차이점은 parent의 컨텍스트와 file, lock,
+ * page를 몽땅 복사한다는 점이다. Project 3 Virtual Memory에서 Copy On Write를
+ * 하기 전까지는 모든 내용을 복제하는 것으로 보인다.
  */
 static void __do_fork(void *aux) {
   struct intr_frame if_;
@@ -159,15 +197,29 @@ static void __do_fork(void *aux) {
    *       from the fork() until this function successfully duplicates
    *       the resources of parent.
    */
+  if (parent->fd_idx == FDCOUNT_LIMIT)
+    goto error;
 
+  for (int i = 2; i < FDCOUNT_LIMIT; i++) {
+    if (parent->fd_table[i] != NULL) {
+      current->fd_table[i] = file_duplicate(parent->fd_table[i]);
+    } else {
+      current->fd_table[i] = NULL;
+    }
+  }
+  current->fd_idx = parent->fd_idx;
+  if_.R.rax = 0;
   process_init();
 
   /* Finally, switch to the newly created process. */
   // TODO - sema_up(parent.fork_sema)
+  sema_up(&current->fork_sema);
   if (succ)
     do_iret(&if_);
 error:
-  thread_exit();
+  current->exit_status = -1;
+  sema_up(&current->fork_sema);
+  exit(-1);
 }
 
 /* Switch the current execution context to the f_name.
@@ -227,43 +279,50 @@ int process_exec(void *f_name) {
  * does nothing. */
 int process_wait(tid_t child_tid UNUSED) {
   // thread_sleep(150);
-  // TODO - child_list를 순회. pid 없으면 -1 리턴, 있다면 exited 여부 & exit_status 검사
+  // TODO - child_list를 순회. pid 없으면 -1 리턴, 있다면 exited 여부 &
+  // exit_status 검사
   struct thread *curr = thread_current();
+  struct thread *child_th;
   struct list c_list = curr->child_list;
   struct list_elem *e;
-  bool is_child = false;
-  if (!list_empty(&c_list)){
-    for (e= list_begin(&c_list); e != list_end(&c_list); e = list_next(e))
-      if (child_tid == list_entry(e, struct child_info, c_elem)->pid) {
-        is_child = true;
+  struct child_info *ch_info;
+  bool is_child = false;  // 내 자식이 맞는가
+
+  if (!list_empty(&c_list)) {  // 자식이 존재한다면
+    for (e = list_begin(&c_list); e != list_end(&c_list); e = list_next(e)) {
+      ch_info = list_entry(e, struct child_info, c_elem);  // 자식의 유서
+      if (child_tid == ch_info->pid) {  // 기다리려는 자식이 맞다면
+        child_th = ch_info->th;  // 자식의 thread
+        is_child = true;  // 내 자식이 맞다!
         break;
       }
+    }
   }
-  if(is_child ){
-    bool exited = list_entry(e, struct child_info, c_elem)->exited;
-    if (exited == 0){
-      sema_init(&curr->wait_sema, 0);
-      sema_down(&curr->wait_sema);
+  if (is_child) {  // 기다리려는 자식이 내 자식이 맞는 경우
+    bool exited = ch_info->exited;
+    if (exited == 0) {  // 자식이 아직 살아있다면
+      sema_down(&child_th->wait_sema);  // 자식이 죽을 때까지 기다림
     }
 
-    int child_status = list_entry(e, struct child_info, c_elem)->exit_status;
-    list_remove(e);
+    int child_status = ch_info->exit_status;  // 자식의 사망 원인 조사
+    list_remove(e);  // 호적에서 제거
+    free(ch_info);  // 주민등록 말소 (사망신고 처리)
     return child_status;
-  }else{
+  } else {  // 기다리려는 자식이 내 자식이 아닌 경우
     return -1;
   }
-  
 
   /* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
    * XXX:       to add infinite loop here before
    * XXX:       implementing the process_wait. */
-  
+
   /**
-   * cases: 
+   * cases:
    * - 자식이 살아있는 경우) sema_down until child process die with `exit`
-   * - 자식이 살아있었는데 비정상적으로 종료된 경우) 자식이 sema_up을 해주고 죽어야 함.
+   * - 자식이 살아있었는데 비정상적으로 종료된 경우) 자식이 sema_up을 해주고
+   * 죽어야 함.
    * - 자식이 이미 죽은 경우) exited이 true라서 바로 exit_status를 리턴.
-   * 
+   *
    * TODO child가 exit할 때 sema_up을 호출하여 깨어나도록 본인 스레드의
    * semaphore를 낮춘다. 이때 semaphore의 값을 0으로 바꿔주어야 한다.
    */
@@ -272,20 +331,39 @@ int process_wait(tid_t child_tid UNUSED) {
 
 /* Exit the process. This function is called by thread_exit (). */
 void process_exit(void) {
-  struct thread *curr = thread_current();
+  struct thread *t = thread_current();
   /* TODO: Your code goes here.
    * TODO: Implement process termination message (see
    * TODO: project2/process_termination.html).
-   * TODO: We recommend you to implement process resource cleanup here. 
-   * - file 해제
-   * - free page (malloced memory?)
-   * - 모든 semaphore up
-   * - 부모의 child_list 원소를 수정. { exit_status, exited }
-   * - 부모 프로세스에게 exit status를 전달
-	 * */
+   * TODO: We recommend you to implement process resource cleanup here.
+   */
+  // file 해제
+  for (int i = 2; i < t->fd_idx; i++) {
+    if (t->fd_table[i] != NULL) {
+      close(i);
+    }
+  }
+  palloc_free_multiple(t->fd_table, FDT_PAGES);
 
-  // sema_up(&curr->parent->wait_sema);
-  // sema_up(&curr->parent->exit_sema); 뭐 하는 놈인지
+  // 부모의 child_list 원소를 수정. { exit_status, exited }
+  if (t->parent != NULL) {
+    struct list *c_list = &t->parent->child_list;
+    for (struct list_elem *e = list_begin(&c_list); e != list_end(&c_list); e = list_next(e)) {
+      struct child_info *my_info = list_entry(e, struct child_info, c_elem);
+      if (t->tid == my_info->pid) {
+        my_info->exit_status = t->status;
+        my_info->exited = 1;
+        break;
+      }
+    }
+  }
+
+  while (!list_empty(&t->child_list)) {
+    struct child_info *ch_info = list_entry(list_pop_front(&t->child_list), struct child_info, c_elem);
+    free(ch_info);
+  }
+  // 모든 semaphore up
+  sema_up(&t->wait_sema);
 
   process_cleanup();
 }

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -163,6 +163,7 @@ static void __do_fork(void *aux) {
   process_init();
 
   /* Finally, switch to the newly created process. */
+  // TODO - sema_up(parent.fork_sema)
   if (succ)
     do_iret(&if_);
 error:
@@ -229,9 +230,15 @@ int process_wait(tid_t child_tid UNUSED) {
   /* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
    * XXX:       to add infinite loop here before
    * XXX:       implementing the process_wait. */
+  // TODO - child_list를 순회. pid 없으면 -1 리턴, 있다면 exited 여부 & exit_status 검사
   /**
+   * cases: 
+   * - 자식이 살아있는 경우) sema_down until child process die with `exit`
+   * - 자식이 살아있었는데 비정상적으로 종료된 경우) 자식이 sema_up을 해주고 죽어야 함.
+   * - 자식이 이미 죽은 경우) exited이 true라서 바로 exit_status를 리턴.
+   * 
    * TODO child가 exit할 때 sema_up을 호출하여 깨어나도록 본인 스레드의
-   * semaphore를 낮춘다.
+   * semaphore를 낮춘다. 이때 semaphore의 값을 0으로 바꿔주어야 한다.
    */
   // sema_down(&thread_current()->wait_sema);
   return -1;
@@ -244,16 +251,15 @@ void process_exit(void) {
    * TODO: Implement process termination message (see
    * TODO: project2/process_termination.html).
    * TODO: We recommend you to implement process resource cleanup here. 
+   * - file 해제
+   * - free page (malloced memory?)
+   * - 모든 semaphore up
+   * - 부모의 child_list 원소를 수정. { exit_status, exited }
+   * - 부모 프로세스에게 exit status를 전달
 	 * */
+
   // sema_up(&curr->parent->wait_sema);
-  // sema_up(&curr->parent->exit_sema);
-  // sema_up(&curr->parent->fork_sema);
-  
-  // TODO - file 해제
-  
-  // TODO - free page
-  
-  // TODO - 부모 프로세스에게 exit status를 전달
+  // sema_up(&curr->parent->exit_sema); 뭐 하는 놈인지
 
   process_cleanup();
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -98,6 +98,7 @@ void syscall_handler(struct intr_frame *f UNUSED) {
       exit(f->R.rdi);
       break;
     case SYS_FORK:
+      thread_current()->bf = *f;
       f->R.rax = fork(f->R.rdi);
       break;
     case SYS_EXEC:
@@ -164,7 +165,6 @@ pid_t fork(const char *thread_name) {
 }
 
 int exec(const char *file) {
-  check_address(file);
   return 0;
 }
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -160,7 +160,9 @@ void exit(int status) {
  */
 pid_t fork(const char *thread_name) {
   check_address(thread_name);
-  process_fork(thread_name, NULL);
+  // TODO - do wait until child process done fork 
+  // sema_down(cur.fork_sema)
+  return process_fork(thread_name, NULL);
 }
 
 int exec(const char *file) {

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -169,9 +169,7 @@ int exec(const char *file) {
   return 0;
 }
 
-int wait(pid_t pid) {
-  return 0;
-}
+int wait(pid_t pid) { return process_wait(pid); }
 //! SECTION - Process based System Call
 // SECTION - File based System Call
 bool create(const char *file, unsigned initial_size) {


### PR DESCRIPTION
## 스레드 및 프로세스 관리 코드 재구성

**요약**

- `process.c` 및 `syscall.c`에서 `list` 더블 포인터 참조를 하는 실수를 수정했습니다. (`process_fork`, `process_wait`, `process_exit`)
- `process.c:process_exit`에서 자식 프로세스의 `exit_status`를 `child_info` 구조체에 갱신하는 코드를 수정했습니다.
- `thread::bf : intr_frame` 멤버를 추가하여 자식 프로세스를 fork할 때 부모 프로세스의 유저레벨 컨텍스트를 보존하도록 만들었습니다. `__do_fork`가 호출될 당시의 부모의 컨텍스트는 유저레벨이 아닌 커널레벨의 컨텍스트 (`process_fork`)를 가지고 있다는 점!