### PR TITLE
fix(fd-lock-position)

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -37,8 +37,8 @@ cd build
 # pintos --fs-disk filesys.dsk -p tests/userprog/args-single:args-single -- -q -f run 'args-single onearg'
 # pintos --fs-disk filesys.dsk -p tests/userprog/args-single:args-single -- -f run 'args-single onearg'
 # pintos --fs-disk filesys.dsk -p tests/userprog/fork-once:fork-once --gdb -- -f run 'fork-once'
-# pintos --fs-disk -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt -- -q -f run read-normal
+pintos --fs-disk=10 -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt -- -q -f run read-normal
 # pintos --fs-disk=10 -p tests/userprog/close-normal:close-normal -p ../../tests/userprog/sample.txt:sample.txt --gdb -- -q -f  run 'close-normal'
 # pintos --gdb -v -k --fs-disk=10 -p tests/userprog/exec-once:exec-once -p tests/userprog/child-simple:child-simple -- -q   -f run exec-once
 # pintos --gdb -v -k --fs-disk=10 -p tests/userprog/exec-missing:exec-missing -- -q   -f run exec-missing
-pintos --gdb -v -k --fs-disk=10 -p tests/userprog/rox-child:rox-child -p tests/userprog/child-rox:child-rox -- -q -f run rox-child
+# pintos --gdb -v -k --fs-disk=10 -p tests/userprog/read-zero:read-zero -p ../../tests/userprog/sample-text:sample-text -- -q -f run read-zero

--- a/include/filesys/inode.h
+++ b/include/filesys/inode.h
@@ -20,4 +20,8 @@ void inode_deny_write (struct inode *);
 void inode_allow_write (struct inode *);
 off_t inode_length (const struct inode *);
 
+// SECTION - Additional Decl
+struct lock *inode_get_lock(struct inode *ino);
+// !SECTION - Additional Decl
+
 #endif /* filesys/inode.h */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -30,7 +30,6 @@ static void process_cleanup(void);
 static bool load(const char *file_name, struct intr_frame *if_);
 static void initd(void *f_name);
 static void __do_fork(void *);
-struct lock load_lock;
 
 /* General process initializer for initd and other process. */
 static void process_init(void) { struct thread *current = thread_current(); }
@@ -67,7 +66,6 @@ static void initd(void *f_name) {
 #endif
 
   process_init();
-  lock_init(&load_lock);
 
   if (process_exec(f_name) < 0)
     PANIC("Fail to launch initd\n");


### PR DESCRIPTION
이 커밋 내용을 분석하고 적절한 커밋 메시지와 내용을 요약해보겠습니다.

**커밋 메시지:**
"Add file locking mechanism in inode.c and syscall.c"

**커밋 내용 요약:**
이 커밋은 두 개의 파일, `inode.c`와 `syscall.c`에서 변경사항을 포함하고 있습니다. 변경사항은 다음과 같습니다:

1. `inode.c` 파일에서:
   - `struct inode` 구조체에 새로운 필드인 `filesys_lock`이 추가되었습니다. 이 lock은 배타적인 read와 write를 지원합니다.
   - `inode_get_lock` 함수가 추가되었습니다. 이 함수는 해당 inode의 파일 시스템 lock을 반환합니다.

2. `syscall.c` 파일에서:
   - `syscall_init` 함수에서는 더 이상 `filesys_lock`을 초기화하지 않습니다.
   - `read` 및 `write` 시스템 콜에서 파일을 다룰 때, 해당 파일의 inode에 있는 파일 시스템 lock을 사용하여 배타적인 접근을 관리합니다.

이러한 변경사항은 파일 시스템에 대한 동시 접근을 관리하기 위한 lock 메커니즘을 도입하고, 이를 `inode.c`와 `syscall.c`에서 사용하도록 합니다.