### PR TITLE
fork 구현 성공 및 syscall 조건 수정

### DIFF
--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -5,6 +5,10 @@ struct page;
 enum vm_type;
 
 struct anon_page {
+    vm_initializer *init;
+    enum vm_type type;
+    void *aux;
+    bool (*page_initializer) (struct page *, enum vm_type, void *kva);
 };
 
 void vm_anon_init (void);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -46,6 +46,8 @@ struct page {
 	void *va;              /* user space: start virtual address of page */
 	struct frame *frame;   /* Back reference for frame */
 
+	bool writable;		 /* Writable or not. If writable, can be modified
+	                          * and saved to the file. */
 	/* Your implementation */
 
 	struct hash_elem hash_elem; // hash element for supplemental page table

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -20,6 +20,7 @@
 #include "filesys/file.h"
 #include "filesys/inode.h"
 #include "devices/input.h"
+#include "vm/vm.h"
 
 /* System call.
  *
@@ -72,9 +73,15 @@ int dup2(int oldfd, int newfd);
  * @note 해당 함수는 유저 프로그램을 종료시켜줍니다.
  */
 void check_address(const void *uaddr) {
-  if (is_kernel_vaddr(uaddr) || pml4_get_page(thread_current()->pml4, uaddr) == NULL) {
-		exit(-1);
-  } 
+  // if (is_kernel_vaddr(uaddr) || pml4_get_page(thread_current()->pml4, uaddr) == NULL) {
+	// 	exit(-1);
+  // } 
+  
+  if (is_kernel_vaddr(uaddr) 
+      || pml4_get_page(thread_current()->pml4, uaddr) == NULL
+      && spt_find_page(&thread_current()->spt, pg_round_down(uaddr)) == NULL) {
+    exit(-1);
+  }
 }
 
 void syscall_init(void) {
@@ -137,7 +144,7 @@ void syscall_handler(struct intr_frame *f UNUSED) {
       close(f->R.rdi);
       break;
     default:
-      printf("system call!\n");
+      // printf("system call!\n");
       thread_exit();
   }
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -204,10 +204,9 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
     }
   } else {
   	/* 여기서부터는 page가 존재하지 않는 요청에 대해 처리 수행 - 명시적인 할당 요청이 없었음 */
-    if (upage_entry < USER_STACK) {
-      // TODO 명확한 조건을 추가해야 한다.
-      // if pg round up (va) is exist, then stack growth
-      // NOTE - 한번에 4KB 이상의 스택을 달라고 하는 양심없는 유저는 걸리지 않는다...
+    if ((uint64_t)f->rsp <= (uint64_t)addr && (uint64_t)addr < USER_STACK) {
+      // stack growth with legitimate stack pointer
+      // `CALL` 명령과 함께 rsp가 증가한 상태로 page fault가 발생해야만 OK
       vm_stack_growth(upage_entry);
       return true;
     }


### PR DESCRIPTION
55 of 141 tests failed.

1. fork (supplement_page_table_copy)
  - 부모의 spt 를 복사해오면서 frame이 존재하는 page는 새로운 frame을 할당받아 내용 복사 후 전달

2. syscall (check_address)
  - write, read, open 등 주소값의 유효성을 확인할 때 lazy_load의 경우 pml4만 확인하는 경우 위험하다.
    - pml4에는 등록되어 있지 않아도 spt page는 존재할 경우는 유효한 주소값으로 판단해야 한다.
    - 이 조건을 달성하기 위해서 pml4_get_page 와 spt_find_page 둘 다 실패할경우 유효하지 않다고 판단한다.
