### PR TITLE
feat(dbg) Modify launch.json to debug on vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "type": "gdb",
             "request": "attach",
-            "name": "Attach to gdbserver : threads",
+            "name": "Attach to pintos 🧲",
             "executable": "${workspaceRoot}/vm/build/kernel.o",
             "target": "localhost:1234",
             "remote": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,28 +5,14 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "pintos attach",
-            "type": "cppdbg",
+            "type": "gdb",
             "request": "attach",
-            "program": "${workspaceRoot}/threads/build/kernel.o",
-            "MIMode": "gdb",
-            "miDebuggerServerAddress": "localhost:1234",
-            "miDebuggerPath": "/usr/bin/gdb",
-            "miDebuggerArgs": "",
-            "useExtendedRemote": true,
-            "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                },
-                {
-                    "description": "Set Disassembly Flavor to Intel",
-                    "text": "-gdb-set disassembly-flavor intel",
-                    "ignoreFailures": true
-                }
-            ]
+            "name": "Attach to gdbserver : threads",
+            "executable": "${workspaceRoot}/vm/build/kernel.o",
+            "target": "localhost:1234",
+            "remote": true,
+            "cwd": "${workspaceRoot}",
+            "valuesFormatting": "parseText"
         }
-        
     ]
 }


### PR DESCRIPTION
##  사용법

1.  build 디렉토리로 이동하여 pintos gdb 옵션을 준 상태로 실행시킵니다
2.  vscode 상에서 명령줄을 열어 "C/C++ debug file"  >  launch.json에 적힌 name과 동일한 configuration을 찾습니다
3.  PROFITw

