### PR TITLE
[필독!] anon_destroy, uninit_destroy 완성

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "type": "gdb",
             "request": "attach",
-            "name": "Attach to gdbserver : threads",
+            "name": "Attach to pintos 🧲",
             "executable": "${workspaceRoot}/vm/build/kernel.o",
             "target": "localhost:1234",
             "remote": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,28 +5,14 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "pintos attach",
-            "type": "cppdbg",
+            "type": "gdb",
             "request": "attach",
-            "program": "${workspaceRoot}/threads/build/kernel.o",
-            "MIMode": "gdb",
-            "miDebuggerServerAddress": "localhost:1234",
-            "miDebuggerPath": "/usr/bin/gdb",
-            "miDebuggerArgs": "",
-            "useExtendedRemote": true,
-            "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                },
-                {
-                    "description": "Set Disassembly Flavor to Intel",
-                    "text": "-gdb-set disassembly-flavor intel",
-                    "ignoreFailures": true
-                }
-            ]
+            "name": "Attach to gdbserver : threads",
+            "executable": "${workspaceRoot}/vm/build/kernel.o",
+            "target": "localhost:1234",
+            "remote": true,
+            "cwd": "${workspaceRoot}",
+            "valuesFormatting": "parseText"
         }
-        
     ]
 }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ C 코드 포매팅 (`C_Cpp.clang_format_style`)은 LLVM을 사용합니다. 일�
 }
 ```
 
+uninit.h 와 vm.h의 경우 각각 ifndef 구문으로 한번만 정의하도록 제한하고 있지만 내부적으로 include 헤더 위치에 따라서 순환문제가 발생합니다. 이 두 파일에 대해서는 전체 formatting을 수행하지 않아야 합니다.
+
+formatting이 필요한 경우 일부 영역만 포매팅을 적용하는 "Format Selection"을 사용하도록 합니다.
+
 [Doxygen Documentation Generator](https://marketplace.visualstudio.com/items?itemName=cschlosser.doxdocgen)를 사용하여 기존에 `///` 또는 `/***/`을 사용한 docstring 자동생성에 더 많은 기능과 자동완성을 제공해 줄 수 있습니다.
 
 [Markdown Lint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)는 md파일을 작성할 때 파일 깨지는 현상을 사전에 방지해 줄 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Project 3에서 팀이 섞이고 코드가 섞이기 때문에 혼란을 최소�
 
 C 코드 포매팅 (`C_Cpp.clang_format_style`)은 LLVM을 사용합니다. 일단 자주 사용하는 파일만 전체 포매팅 돌렸습니다.
 
+```json
+{
+  "C_Cpp.clang_format_style": "{ ColumnLimit: 80, IndentWidth: 4, TabWidth: 4 }",
+  "C_Cpp.clang_format_fallbackStyle": "LLVM",
+}
+```
+
 [Doxygen Documentation Generator](https://marketplace.visualstudio.com/items?itemName=cschlosser.doxdocgen)를 사용하여 기존에 `///` 또는 `/***/`을 사용한 docstring 자동생성에 더 많은 기능과 자동완성을 제공해 줄 수 있습니다.
 
 [Markdown Lint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)는 md파일을 작성할 때 파일 깨지는 현상을 사전에 방지해 줄 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ C 코드 포매팅 (`C_Cpp.clang_format_style`)은 LLVM을 사용합니다. 일�
 
 ```json
 {
-  "C_Cpp.clang_format_style": "{ ColumnLimit: 80, IndentWidth: 4, TabWidth: 4 }",
+  "C_Cpp.clang_format_style": "{ ColumnLimit: 80, IndentWidth: 2, TabWidth: 2 }",
   "C_Cpp.clang_format_fallbackStyle": "LLVM",
 }
 ```

--- a/do.sh
+++ b/do.sh
@@ -42,4 +42,5 @@ cd build
 # pintos --gdb -v -k --fs-disk=10 -p tests/userprog/exec-once:exec-once -p tests/userprog/child-simple:child-simple -- -q   -f run exec-once
 # pintos --gdb -v -k --fs-disk=10 -p tests/userprog/exec-missing:exec-missing -- -q   -f run exec-missing
 # pintos --gdb -v -k --fs-disk=10 -p tests/userprog/read-zero:read-zero -p ../../tests/userprog/sample-text:sample-text -- -q -f run read-zero
-pintos $1 -v -k --fs-disk=10 -p tests/userprog/args-none:args-none --swap-disk=4 -- -q   -f run args-none
+# pintos $1 -v -k --fs-disk=10 -p tests/userprog/args-none:args-none --swap-disk=4 -- -q   -f run args-none
+pintos -v -k -T 60 -m 20   --fs-disk=10 -p tests/userprog/args-many:args-many --swap-disk=4 -- -q   -f run 'args-many a b c d e f g h i j k l m n o p q r s t u v'

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -52,6 +52,8 @@ struct page {
 
 	struct hash_elem hash_elem; // hash element for supplemental page table
 	
+	char __unused[49];
+	
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
 	union {

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -914,16 +914,12 @@ static bool setup_stack(struct intr_frame *if_) {
   bool success = false;
   void *stack_bottom = (void *)(((uint8_t *)USER_STACK) - PGSIZE);
 
-  if (vm_alloc_page_with_initializer(VM_ANON, stack_bottom, true, pml4_setter, NULL)) {
-    /* Map the stack on stack_bottom and claim the page immediately.
-    * If success, set the rsp accordingly.
-    * You should mark the page is stack. */
+  /* Map the stack on stack_bottom and claim the page immediately.
+  * If success, set the rsp accordingly.
+  * You should mark the page is stack. */
+  if ((success = vm_claim_page(stack_bottom))) {
     if_->rsp = USER_STACK;
-    /* TODO: You should mark the page is stack. */
-    success = true;
-    vm_claim_page(stack_bottom);
   }
-
   return success;
 }
 #endif /* VM */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -28,6 +28,7 @@
 #endif
 
 static struct hand_in {
+  uint64_t size;
   struct file *file;
   off_t ofs;
   uint8_t *upage;
@@ -880,6 +881,7 @@ static bool load_segment(struct file *file, off_t ofs, uint8_t *upage,
 
     hand_in = (struct hand_in *) malloc(sizeof(struct hand_in));
     *hand_in = (struct hand_in) {
+      .size = sizeof(struct hand_in),
       .file = file,
       .ofs = ofs,
       .upage = upage,

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -921,6 +921,7 @@ static bool setup_stack(struct intr_frame *if_) {
     if_->rsp = USER_STACK;
     /* TODO: You should mark the page is stack. */
     success = true;
+    vm_claim_page(stack_bottom);
   }
 
   return success;

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -67,4 +67,8 @@ anon_swap_out (struct page *page) {
 static void
 anon_destroy (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+	if (page->frame != NULL) {
+		free(page->frame);
+	}
+	// NOTE - anon or file로 변경되는 순간 aux는 이미 사용하고 free한 상태이다.
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -44,6 +44,8 @@ file_backed_swap_out (struct page *page) {
 static void
 file_backed_destroy (struct page *page) {
 	struct file_page *file_page UNUSED = &page->file;
+	// TODO dirty bit를 확인해서, 변경된 기록이 있으면 파일에 내용을 쓰고 destory 수행
+	
 }
 
 /* Do the mmap */

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -56,7 +56,6 @@ uninit_initialize (struct page *page, void *kva) {
 	return uninit->page_initializer (page, uninit->type, kva) &&
 		(init ? init (page, aux) : true);
 }
-#include <stdio.h>
 
 /* Free the resources hold by uninit_page. Although most of pages are transmuted
  * to other page objects, it is possible to have uninit pages when the process

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -10,6 +10,7 @@
 
 #include "vm/vm.h"
 #include "vm/uninit.h"
+#include "threads/malloc.h"
 
 static bool uninit_initialize (struct page *page, void *kva);
 static void uninit_destroy (struct page *page);
@@ -55,14 +56,23 @@ uninit_initialize (struct page *page, void *kva) {
 	return uninit->page_initializer (page, uninit->type, kva) &&
 		(init ? init (page, aux) : true);
 }
+#include <stdio.h>
 
 /* Free the resources hold by uninit_page. Although most of pages are transmuted
  * to other page objects, it is possible to have uninit pages when the process
  * exit, which are never referenced during the execution.
- * PAGE will be freed by the caller. */
+ * PAGE will be freed by the caller. 
+ * 
+ * frame이 아직 존재하지 않기 때문에 구체적인 destroy 함수를 호출하지 않습니다.
+ * dirty flag에 의한 file write도 일어나지 않습니다.
+ * */
 static void
 uninit_destroy (struct page *page) {
-	struct uninit_page *uninit UNUSED = &page->uninit;
-	/* TODO: Fill this function.
-	 * TODO: If you don't have anything to do, just return. */
+	struct uninit_page *uninit = &page->uninit;
+	// find out vm type and free the resources accordingly
+  if (uninit && uninit->aux) {
+		// aux에 주소가 아니라 값을 넣은 경우 큰일남
+    free (uninit->aux);
+  }
+	// 페이지 free는 필요 없습니다
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -317,10 +317,9 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
   return true;
 }
 
-static bool remove_pages(struct hash_elem *e, void *aux UNUSED) {
+static void remove_pages(struct hash_elem *e, void *aux UNUSED) {
   struct page *p = hash_entry(e, struct page, hash_elem);
   vm_dealloc_page(p);
-  return true;
 }
 
 /* Free the resource hold by the supplemental page table */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -317,12 +317,19 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
   return true;
 }
 
+static bool remove_pages(struct hash_elem *e, void *aux UNUSED) {
+  struct page *p = hash_entry(e, struct page, hash_elem);
+  vm_dealloc_page(p);
+  return true;
+}
+
 /* Free the resource hold by the supplemental page table */
 void
 supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
 	/* TODO: Destroy all the supplemental_page_table hold by thread and
 	 * TODO: writeback all the modified contents to the storage. */
-  // hash_apply(&spt->page_map, vm_dealloc_page_each);
+  hash_clear(&spt->page_map, remove_pages);
+  ASSERT (hash_size(&spt->page_map) == 0);
 }
 
 /** 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -216,6 +216,11 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
   // return vm_do_claim_page (page);
 }
 
+void vm_dealloc_page_each(struct hash_elem *elem, void *aux UNUSED) {
+  struct page *page = hash_entry(elem, struct page, hash_elem);
+  vm_dealloc_page(page);
+}
+
 /* Free the page.
  * DO NOT MODIFY THIS FUNCTION. */
 void
@@ -316,6 +321,7 @@ void
 supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
 	/* TODO: Destroy all the supplemental_page_table hold by thread and
 	 * TODO: writeback all the modified contents to the storage. */
+  // hash_apply(&spt->page_map, vm_dealloc_page_each);
 }
 
 /** 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -217,11 +217,6 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
   // return vm_do_claim_page (page);
 }
 
-void vm_dealloc_page_each(struct hash_elem *elem, void *aux UNUSED) {
-  struct page *page = hash_entry(elem, struct page, hash_elem);
-  vm_dealloc_page(page);
-}
-
 /* Free the page.
  * DO NOT MODIFY THIS FUNCTION. */
 void
@@ -333,7 +328,7 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
   return true;
 }
 
-static void remove_pages(struct hash_elem *e, void *aux UNUSED) {
+static void vm_dealloc_page_each(struct hash_elem *e, void *aux UNUSED) {
   struct page *p = hash_entry(e, struct page, hash_elem);
   vm_dealloc_page(p);
 }
@@ -343,7 +338,7 @@ void
 supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
 	/* TODO: Destroy all the supplemental_page_table hold by thread and
 	 * TODO: writeback all the modified contents to the storage. */
-  hash_clear(&spt->page_map, remove_pages);
+  hash_clear(&spt->page_map, vm_dealloc_page_each);
   ASSERT (hash_size(&spt->page_map) == 0);
 }
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -195,7 +195,7 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
 	void *upage_entry = pg_round_down(addr);
 
   /* Validate the fault */
-  // ASSERT (is_user_vaddr(addr)); // if page's type is uninit, BOOM
+  ASSERT (is_user_vaddr(addr)); // if page's type is uninit, BOOM
   // printf("[*] 💥 fault_address: %p\n", addr);
 
   if ((page = spt_find_page(spt, upage_entry)) != NULL) {

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -195,7 +195,8 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
 	void *upage_entry = pg_round_down(addr);
 
   /* Validate the fault */
-  ASSERT (is_user_vaddr(addr)); // if page's type is uninit, BOOM
+  // ASSERT (is_user_vaddr(addr)); // if page's type is uninit, BOOM
+  // printf("[*] 💥 fault_address: %p\n", addr);
 
   if ((page = spt_find_page(spt, upage_entry)) != NULL) {
     // case 1. file-backed, case 2. swap-out, case 3. first stack


### PR DESCRIPTION
aux로 사용될 구조체 두가지 (fie_page, hand_in)은 반드시 첫 필드로 구조체 크기를 갖고있어야 합니다.

이는 spt copy에서 전달된 인자의 크기를 확인하기 위함입니다.