### PR TITLE
fix(mmap-overlap) pass

### DIFF
--- a/include/vm/file.h
+++ b/include/vm/file.h
@@ -6,12 +6,21 @@
 struct page;
 enum vm_type;
 
+/**
+ * @brief union of struct page, used for VM_FILE
+ * lazy file load를 위한 인자전달 구조체
+ * @implements get_size_of_aux
+ */
 struct file_page {
+	uint64_t aux_size;
 	struct file *file;
 	off_t ofs;
+	uint8_t *upage;
+	uint32_t read_bytes;
+	uint32_t zero_bytes;
 	bool writable;
 	size_t connected_page_cnt;
-  	size_t connected_page_idx;
+	size_t connected_page_idx;
 };
 
 void vm_file_init (void);

--- a/vm/file.c
+++ b/vm/file.c
@@ -1,6 +1,7 @@
 /* file.c: Implementation of memory backed file object (mmaped object). */
 
 #include "vm/vm.h"
+#include "threads/mmu.h"
 
 static bool file_backed_swap_in (struct page *page, void *kva);
 static bool file_backed_swap_out (struct page *page);
@@ -55,6 +56,4 @@ do_mmap (void *addr, size_t length, int writable,
 }
 
 /* Do the munmap */
-void
-do_munmap (void *addr) {
-}
+void do_munmap(void *addr) {}


### PR DESCRIPTION
- `vm_alloc_with_initializer`가 `spt_find_page != NULL`이 아니더라도 true를 반환하는 문제가 있었습니다.
- 그래서 `remove_failed_pages` 하지않고 미리 반복문을 돌면서 `spt_find_page`가 NULL이 아닌경우 바로 리턴하도록 조치했습니다.