### PR TITLE
feat(process_exit) Add hash_destroy after cleanup

### DIFF
--- a/userprog/process.c
+++ b/userprog/process.c
@@ -383,6 +383,7 @@ void process_exit(void) {
   sema_up(&t->wait_sema);
 
   process_cleanup();
+  hash_destroy(&t->spt.page_map, NULL);
 }
 
 /* Free the current process's resources. */


### PR DESCRIPTION
## process_exit

`process_cleanup` 안에서 `hash_destroy`를 호출했더니 123개 테스트케이스가 실패했습니다  왜냐하면 `process_exec`에서도 사용하기 때문이죠  하지만 해시 버킷들또한  동적으로 할당받은 놈들이기 때문에 결국 `free`해주어야 합니다

따라서  명시적으로 `process_exit`  타이밍에 `hash_destroy`를 호출하는 것으로 자원해제를 진행했습니다
