### PR TITLE
mmap write

### DIFF
--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -519,7 +519,7 @@ void *mmap (void *addr, size_t length, int writable, int fd, off_t offset) {
   }
 
   void *cursor = addr;
-  while (actual_file_len > 0) {
+  while ((uint64_t)cursor < (uint64_t)addr + length) {
     void *upage = cursor;
     size_t read_bytes = actual_file_len < PGSIZE ? actual_file_len : PGSIZE;
     size_t zero_bytes = PGSIZE - read_bytes;

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -70,5 +70,4 @@ anon_destroy (struct page *page) {
 	if (page->frame != NULL) {
 		free(page->frame);
 	}
-	// NOTE - anon or file로 변경되는 순간 aux는 이미 사용하고 free한 상태이다.
 }


### PR DESCRIPTION
- mmap testcase 분석
- feat(mmap, munmap): 구현 중 (mmap-close fail)
- feat(mmap): lazy_load_file을 위한 file duplicate 수행
- fix(mmap): validate file from fd
- helpme(destroy) add uninit_destroy
- feat(setup_stack) eager loading on first stack
- feat(setup_stack) claim page immediately
- feat: page fault 발생 시 user_addr 검증
- feat(spt kill): spt 테이블의 페이지 전부를 삭제하는 기능 구현.
- fix(remove_page): return type 변경
- feat(spt copy): **주의** 부모 페이지의 aux를 복사하는 과정 추가
- refactor(vm.c, uninit.c): 함수명 변경 및 불필요한 내용 삭제
- feat(try handle fault) ASSERT ⟶ if statement
- fix(mmap-overlap) Delete remove_failed_pages and check consecutivity pages
- helpme(mmap-unmap) mmap-write를 해결했더니 munmap이 터진다
