### PR TITLE
feat(pt-write-code2) pass

### DIFF
--- a/include/threads/mmu.h
+++ b/include/threads/mmu.h
@@ -20,6 +20,10 @@ void pml4_set_dirty (uint64_t *pml4, const void *upage, bool dirty);
 bool pml4_is_accessed (uint64_t *pml4, const void *upage);
 void pml4_set_accessed (uint64_t *pml4, const void *upage, bool accessed);
 
+// SECTION - Additional Declarations
+bool pml4_is_writable (uint64_t *pml4, const void *vpage);
+// !SECTION - Additional Declarations
+
 #define is_writable(pte) (*(pte) & PTE_W)
 #define is_user_pte(pte) (*(pte) & PTE_U)
 #define is_kern_pte(pte) (!is_user_pte (pte))

--- a/threads/mmu.c
+++ b/threads/mmu.c
@@ -279,6 +279,14 @@ pml4_is_dirty (uint64_t *pml4, const void *vpage) {
 	return pte != NULL && (*pte & PTE_D) != 0;
 }
 
+/**
+ * @brief 가상주소에 연결된 PTE가 쓰기 가능한지 여부를 반환한다.
+ */
+bool pml4_is_writable (uint64_t *pml4, const void *vpage) {
+	uint64_t *pte = pml4e_walk (pml4, (uint64_t) vpage, false);
+  return pte!= NULL && (*pte & PTE_W)!= 0;
+}
+
 /* Set the dirty bit to DIRTY in the PTE for virtual page VPAGE
  * in PML4. */
 void

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -1,4 +1,3 @@
-#include "userprog/syscall.h"
 #include "lib/stdio.h"
 #include "lib/user/syscall.h"
 
@@ -301,6 +300,11 @@ struct file *fd_to_file(int fd) {
  */
 int read(int fd, void *buffer, unsigned size) {
   check_address(buffer);
+
+  if (!pml4_is_writable(thread_current()->pml4, buffer)) {
+    exit(-1);
+  }
+
   uint8_t *buf = buffer;
   off_t read_count;
 


### PR DESCRIPTION
## `pml4_is_writable(pml4, uaddr)` 추가

위 함수는 pte 값의 플래그를 참조하여 인자로 들어온 유저 가상주소가 쓰기 가능한 주소인지 여부를  판별합니다. pt-write-code2 테스트케이스는 `read(fd, buf, len)`의 두번째 인자로 무려 `test_main`, 코드 세그먼트에 있는 주소를 넣어버리는 만행을 저지릅니다  따라서 우리는 `read` 시스템콜 안에서 추가적인 조건을 걸어야 합니다
