### PR TITLE
feat(cow-read) and α

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -48,4 +48,4 @@ cd build
 
 ### COW 
 #
-pintos $1 -v -k -m 20 --fs-disk=10 -p tests/vm/cow/cow-simple:cow-simple  -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 -- -q   -f run cow-simple
+pintos $1 -v -k -m 20 --fs-disk=10 -p tests/vm/cow/cow-simple:cow-simple  -p ../../tests/vm/large.txt:sample.txt --swap-disk=4 -- -q   -f run cow-simple

--- a/do.sh
+++ b/do.sh
@@ -43,4 +43,9 @@ cd build
 # pintos --gdb -v -k --fs-disk=10 -p tests/userprog/exec-missing:exec-missing -- -q   -f run exec-missing
 # pintos --gdb -v -k --fs-disk=10 -p tests/userprog/read-zero:read-zero -p ../../tests/userprog/sample-text:sample-text -- -q -f run read-zero
 # pintos $1 -v -k --fs-disk=10 -p tests/userprog/args-none:args-none --swap-disk=4 -- -q   -f run args-none
-pintos -v -k -T 60 -m 20   --fs-disk=10 -p tests/userprog/args-many:args-many --swap-disk=4 -- -q   -f run 'args-many a b c d e f g h i j k l m n o p q r s t u v'
+#
+#
+
+### COW 
+#
+pintos $1 -v -k -m 20 --fs-disk=10 -p tests/vm/cow/cow-simple:cow-simple  -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 -- -q   -f run cow-simple

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -3,6 +3,8 @@
 
 #include "threads/thread.h"
 
+#define ARGS_LEN 128 // 인자 최대길이
+
 tid_t process_create_initd (const char *file_name);
 tid_t process_fork (const char *name, struct intr_frame *if_);
 int process_exec (void *f_name);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -53,8 +53,6 @@ struct page {
 	struct hash_elem hash_elem; // hash element for supplemental page table
 	struct list_elem frame_elem; // list element for frame list
 	
-	char __unused[49];
-	
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
 	union {

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -51,6 +51,7 @@ struct page {
 	/* Your implementation */
 
 	struct hash_elem hash_elem; // hash element for supplemental page table
+	struct list_elem frame_elem; // list element for frame list
 	
 	char __unused[49];
 	
@@ -69,9 +70,10 @@ struct page {
 /* The representation of "frame" */
 struct frame {
 	void *kva; // kernel virtual address
-	struct page *page; // back reference for page
+	// struct page *page; // back reference for page
+	struct list page_list; // list element for page list
 	uint32_t ref_cnt; // reference count
-	struct list_elem elem // frame table element
+	struct list_elem elem; // frame table element
 };
 
 /* The function table for page operations.

--- a/tests/vm/child-linear.c
+++ b/tests/vm/child-linear.c
@@ -20,6 +20,7 @@ main (int argc, char *argv[])
   size_t i;
 
   /* Encrypt zeros. */
+  // printf("[*] encrypting zeros\n");
   arc4_init (&arc4, key, strlen (key));
   arc4_crypt (&arc4, buf, SIZE);
 

--- a/tests/vm/cow/cow-simple.c
+++ b/tests/vm/cow/cow-simple.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_SIZE (128 * 1024)
 
-static char buffer[2048];
+static char buffer[CHUNK_SIZE + 1];
 
 void
 test_main (void)
@@ -49,7 +49,7 @@ test_main (void)
 	
 	CHECK ((handle = open("sample.txt")) > 1, "open \"sample.txt\"");
 	
-	CHECK (read(handle, buffer, 2048) > 1, "부모: read \"sample.txt\"");
+	CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "부모: read \"sample.txt\"");
 	printf("[*] parent read data: %s\n", buffer);
 
 	pa_parent = get_phys_addr((void *) buffer);
@@ -65,7 +65,7 @@ test_main (void)
           "two phys addrs should be the same. (%p), (%p)", pa_parent, pa_child);
 
 		seek(handle, 0);
-    CHECK (read(handle, buffer, 2048) > 1, "자식: read \"sample.txt\" 읽는다.");
+    CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "자식: read \"sample.txt\" 읽는다.");
 		
 		printf("read bytes: %s\n", buffer);
 		

--- a/tests/vm/cow/cow-simple.c
+++ b/tests/vm/cow/cow-simple.c
@@ -18,66 +18,65 @@ test_main (void)
 	pid_t child;
 	void *pa_parent;
 	void *pa_child;
-	// char *buf = "Lorem ipsum";
-	char buffer_local[2048];
+	char *buf = "Lorem ipsum";
 
-	// CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
-	// pa_parent = get_phys_addr((void*)large);
+	CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
+	pa_parent = get_phys_addr((void*)large);
 
-	// child = fork ("child");
-	// if (child == 0) {
-	// 	CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
+	child = fork ("child");
+	if (child == 0) {
+		CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
 
-	// 	pa_child = get_phys_addr((void*)large);
-	// 	CHECK (pa_parent == pa_child, "two phys addrs should be the same.");
+		pa_child = get_phys_addr((void*)large);
+		CHECK (pa_parent == pa_child, "two phys addrs should be the same.");
 
-	// 	large[0] = '@';
-	// 	CHECK (memcmp (buf, large, strlen (buf)) != 0, "check data change");
+		large[0] = '@';
+		CHECK (memcmp (buf, large, strlen (buf)) != 0, "check data change");
 
-	// 	pa_child = get_phys_addr((void*)large);
-	// 	CHECK (pa_parent != pa_child, "two phys addrs should not be the same.");
-	// 	return;
-	// }
-	// wait (child);
-	// CHECK (pa_parent == get_phys_addr((void*)large), "two phys addrs should be the same.");
-	// CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
+		pa_child = get_phys_addr((void*)large);
+		CHECK (pa_parent != pa_child, "two phys addrs should not be the same.");
+		return;
+	}
+	wait (child);
+	CHECK (pa_parent == get_phys_addr((void*)large), "two phys addrs should be the same.");
+	CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
 	
 	/// Child Read
-	printf("\n[*] Child Read\n\n");
+	// printf("\n[*] Child Read\n\n");
 	
-	int handle;
+	// int handle;
 	
-	CHECK ((handle = open("sample.txt")) > 1, "open \"sample.txt\"");
+	// CHECK ((handle = open("sample.txt")) > 1, "open \"sample.txt\"");
 	
-	CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "부모: read \"sample.txt\"");
-	printf("[*] parent read data: %s\n", buffer);
+	// CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "부모: read \"sample.txt\"");
+	// printf("[*] parent read data: %s\n", buffer);
 
-	pa_parent = get_phys_addr((void *) buffer);
+	// pa_parent = get_phys_addr((void *) buffer);
 	
-	printf("[*] 🍴 포크하기 직전!!\n");
+	// printf("[*] 🍴 포크하기 직전!!\n");
 	
-	child = fork("child");
-	if (child == 0) {
-		// child process
-		printf("[*] child process\n");
-		pa_child = get_phys_addr((void *) buffer);
-    CHECK(pa_parent == pa_child,
-          "two phys addrs should be the same. (%p), (%p)", pa_parent, pa_child);
+	// child = fork("child");
+	// if (child == 0) {
+	// 	// child process
+	// 	printf("[*] child process\n");
+	// 	pa_child = get_phys_addr((void *) buffer);
+  //   CHECK(pa_parent == pa_child,
+  //         "two phys addrs should be the same. (%p), (%p)", pa_parent, pa_child);
 
-		seek(handle, 0);
-    CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "자식: read \"sample.txt\" 읽는다.");
+	// 	seek(handle, 0);
+  //   CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "자식: read \"sample.txt\" 읽는다.");
 		
-		printf("read bytes: %s\n", buffer);
+	// 	printf("read bytes: %s\n", buffer);
 		
-		pa_child = get_phys_addr((void *) buffer);
-		CHECK (pa_parent != pa_child, "two phys addrs should not be the same. (%p), (%p)", pa_parent, pa_child);
-		return;
-	} else {
-		// parent process
-		wait (child);
-		printf("[*] parent process end\n");
-		CHECK (pa_parent == get_phys_addr((void *) buffer), "two phys addrs should be the same.");
-	}
+	// 	pa_child = get_phys_addr((void *) buffer);
+	// 	CHECK (pa_parent != pa_child, "two phys addrs should not be the same. (%p), (%p)", pa_parent, pa_child);
+	// 	return;
+	// } else {
+	// 	// parent process
+	// 	wait (child);
+	// 	printf("[*] parent process end\n");
+	// 	CHECK (pa_parent == get_phys_addr((void *) buffer), "two phys addrs should be the same.");
+	// }
 
 	return;
 }

--- a/threads/start.S
+++ b/threads/start.S
@@ -2,6 +2,7 @@
 #define LONG_MODE (1 << 29)
 #define CR0_PE 0x00000001
 #define CR0_PG (1 << 31)
+#define CR0_WP 0x00010000      /* Write-Protect enable in kernel mode. */
 #define CR4_PAE 0x20
 #define PTE_P 0x1
 #define PTE_W 0x2

--- a/threads/start.S
+++ b/threads/start.S
@@ -98,7 +98,7 @@ fill_pdes:
 
 #### Enable paging
 	mov %cr0, %eax
-	or $(CR0_PE|CR0_PG), %eax
+	or $(CR0_PE|CR0_PG|CR0_WP), %eax
 	mov %eax, %cr0
 
 #### Jump to the long mode

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -830,8 +830,8 @@ static bool lazy_load_segment(struct page *page, void *aux) {
   
   lock_acquire(inode_get_lock(file_get_inode(file)));
 
-  // code segment registration
-  pml4_set_page(t->pml4, page->va, page->frame->kva, writable);
+  // 커널의 세그먼트 적재 시작, writeable true
+  pml4_set_page(t->pml4, page->va, page->frame->kva, true);
 
   /* copy of load_segment when USERPROG */
   ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
@@ -854,6 +854,10 @@ static bool lazy_load_segment(struct page *page, void *aux) {
   free(aux); // 인자 (malloc) free 수행
 
   lock_release(inode_get_lock(file_get_inode(file)));
+
+  // 커널의 세그먼트 적재완료, writeable 원복
+  pml4_set_page(t->pml4, page->va, page->frame->kva, writable);
+
   return true;
 }
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -253,7 +253,7 @@ int process_exec(void *f_name) {
   char *file_name = f_name;
   bool success;
   int i;
-  char **argv = (char *)malloc (sizeof(char) * 128);
+  char **argv = (char **)palloc_get_page(0);
   char *token, *save_ptr; // token화 하기 위한 변수
   int argc = 0;  // argument 개수
 
@@ -283,6 +283,7 @@ int process_exec(void *f_name) {
   /* 유저스택에 인자 추가 */
   argument_stack(argc, argv, &_if);
   palloc_free_page(file_name);
+  palloc_free_page(argv);
   
   /* 프로세스 전환하여 실행 */
   do_iret(&_if);
@@ -429,7 +430,7 @@ void process_activate(struct thread *next) {
  * @brief 초기화된 유저 스택공간에 직접 인자를 추가한다.
  */
 void argument_stack(int argc, char **argv, struct intr_frame *if_) {
-  char *argv_addr[128];
+  char *argv_addr[ARGS_LEN];
 
   for (int i = argc - 1; i >= 0; i--) {
     int argv_len = strlen(argv[i]);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -311,6 +311,10 @@ int read(int fd, void *buffer, unsigned size) {
   check_address(buffer);
   uint8_t *buf = buffer;
   off_t read_count;
+  
+  if (size == 0) {
+    return 0;
+  }
 
   // check buffer address
   struct page *p = spt_find_page(&thread_current()->spt, pg_round_down(buffer));
@@ -318,7 +322,7 @@ int read(int fd, void *buffer, unsigned size) {
     exit(-1);
   }
   
-  printf("[*] in syscall read, p->frame->kva = %p\n", p->frame->kva);
+  // printf("[*] in syscall read, p->frame->kva = %p\n", p->frame->kva);
 
   if (fd == STDIN_FILENO) {  // STDIN일 때
     char key;
@@ -339,6 +343,7 @@ int read(int fd, void *buffer, unsigned size) {
 
     // exclusive read & write
     // lock_acquire(inode_get_lock(file_get_inode(filep))); 
+    *((char *) buffer) = '@'; // try to read to check if page fault occurs
     filesys_lock_acquire();
     read_count = file_read(filep, buffer, size);
     // lock_release(inode_get_lock(file_get_inode(filep)));

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -455,7 +455,7 @@ static bool lazy_load_file(struct page *page, void *aux) {
   size_t connected_page_idx = hand_in->connected_page_idx;
 
   // code segment registration
-  pml4_set_page(thread_current()->pml4, page->va, page->frame->kva, writable);
+  pml4_set_page(thread_current()->pml4, page->va, page->frame->kva, true);
 
   /* copy of load_segment when USERPROG */
   ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
@@ -476,6 +476,9 @@ static bool lazy_load_file(struct page *page, void *aux) {
   memset(upage + read_bytes, 0, zero_bytes);
 
   free(aux); // 인자 (malloc) free 수행
+
+  // code segment 원복
+  pml4_set_page(thread_current()->pml4, page->va, page->frame->kva, writable);
   
   // set not dirty: 파일 내용을 복사하면서 dirty로 체크됨.
   // 이를 해제해두면 memeory에 데이터가 쓸때 dirty가 체크되므로 수정여부를 판단 가능

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -309,7 +309,6 @@ struct file *fd_to_file(int fd) {
  */
 int read(int fd, void *buffer, unsigned size) {
   check_address(buffer);
-
   uint8_t *buf = buffer;
   off_t read_count;
 
@@ -318,6 +317,8 @@ int read(int fd, void *buffer, unsigned size) {
   if (p == NULL || (p->writable == false)) {
     exit(-1);
   }
+  
+  printf("[*] in syscall read, p->frame->kva = %p\n", p->frame->kva);
 
   if (fd == STDIN_FILENO) {  // STDIN일 때
     char key;

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -59,7 +59,7 @@ static bool
 anon_swap_in (struct page *page, void *kva) {
 	struct anon_page *anon_page = &page->anon;
 	if (anon_page->area == -1 || page->frame == NULL) {
-    printf("[*] swap_in failed!: %p\n", page->va);
+    // printf("[*] swap_in failed!: %p\n", page->va);
 		return false;
 	}
 
@@ -115,6 +115,6 @@ anon_destroy (struct page *page) {
   // unlink frame을 직접 해주어야 한다.
   pml4_clear_page(thread_current()->pml4, page->va);
   page->frame->ref_cnt -= 1;
-  page->frame->page = NULL;
+  list_remove(&page->frame_elem);
   page->frame = NULL;
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -128,7 +128,7 @@ file_backed_destroy (struct page *page) {
 	// unlink frame을 직접 해주어야 한다.
 	pml4_clear_page(cur->pml4, page->va);
 	page->frame->ref_cnt -= 1;
-	page->frame->page = NULL;
+	list_remove(&page->frame_elem);
 	page->frame = NULL;
 }
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -347,7 +347,6 @@ vm_do_claim_page (struct page *page) {
 
   bool success = swap_in (page, frame->kva);
   if (success) {
-    pml4_clear_page(thread_current()->pml4, page->va);
     pml4_set_page(thread_current()->pml4, page->va, frame->kva, false); // cow
   }
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -156,9 +156,12 @@ vm_get_victim (void) {
   // e = list_pop_front(&frame_table);
   // list_push_back(&frame_table, e);
 
-  // policy: ref_cnt가 가장 작은 frame을 victim으로 선정
-  { 
-    // list_min 확장
+  {
+    /**
+     * @brief list_min extension
+     * @policy: ref_cnt가 가장 작은 frame을 victim으로 선정. 이때, ref_cnt가
+     * 1보다 작다면 빠르게 반복문을 나간다.
+     */
     if (min != list_end(list)) {
       struct list_elem *e;
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -194,10 +194,6 @@ vm_evict_frame (void) {
     return NULL; // TODO kernel panic?
   }
   
-  if (list_empty (&victim->page_list)) {
-    return victim;
-  }
-
   // page와 frame을 분리
   while (!list_empty (&victim->page_list)) {
     // swap out page element and unlink it

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -284,8 +284,10 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
       vm_stack_growth(upage_entry);
       struct page *_p = spt_find_page(spt, upage_entry);
       if (_p != NULL) {
-        pml4_clear_page(thread_current()->pml4, _p->va);
+        // pml4_clear_page(thread_current()->pml4, _p->va);
         pml4_set_page(thread_current()->pml4, _p->va, _p->frame->kva, false); // cow
+      } else {
+        return false;
       }
 
       return true;


### PR DESCRIPTION
## TL;DR

- start.S에서 커널의 메모리 읽기 권한을 약화시키는 `CR0_WP` 플래그를 켰습니다.
- `CR0_WP` 플래그로 인한 에러를 수정했습니다
- frame과 page 간에 granularity를 1대다로 만들었습니다.
- `struct page` 구조체에 들어있던 무의미한 멤버변수 `char __unused[49]`를 제거했습니다.

## commits

- fix(try_handle_fault) Add return false on spt_find_page is NULL
- Add CR0_WP flag
- feat(CR0_WP) kernel is now 빙다리핫바지
- feat(syscall read) phony write to buffer before file read
- feat(frame) frame:page = 1:N
- close #65
- misc(comment, get_victim)
