### PR TITLE
feat(CopyOnWrite) and All Pass

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -48,4 +48,4 @@ cd build
 
 ### COW 
 #
-pintos $1 -v -k -m 20 --fs-disk=10 -p tests/vm/cow/cow-simple:cow-simple  -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 -- -q   -f run cow-simple
+pintos $1 -v -k -m 20 --fs-disk=10 -p tests/vm/cow/cow-simple:cow-simple  -p ../../tests/vm/large.txt:sample.txt --swap-disk=4 -- -q   -f run cow-simple

--- a/do.sh
+++ b/do.sh
@@ -43,4 +43,9 @@ cd build
 # pintos --gdb -v -k --fs-disk=10 -p tests/userprog/exec-missing:exec-missing -- -q   -f run exec-missing
 # pintos --gdb -v -k --fs-disk=10 -p tests/userprog/read-zero:read-zero -p ../../tests/userprog/sample-text:sample-text -- -q -f run read-zero
 # pintos $1 -v -k --fs-disk=10 -p tests/userprog/args-none:args-none --swap-disk=4 -- -q   -f run args-none
-pintos -v -k -T 60 -m 20   --fs-disk=10 -p tests/userprog/args-many:args-many --swap-disk=4 -- -q   -f run 'args-many a b c d e f g h i j k l m n o p q r s t u v'
+#
+#
+
+### COW 
+#
+pintos $1 -v -k -m 20 --fs-disk=10 -p tests/vm/cow/cow-simple:cow-simple  -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 -- -q   -f run cow-simple

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -3,6 +3,8 @@
 
 #include "threads/thread.h"
 
+#define ARGS_LEN 128 // 인자 최대길이
+
 tid_t process_create_initd (const char *file_name);
 tid_t process_fork (const char *name, struct intr_frame *if_);
 int process_exec (void *f_name);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -53,8 +53,6 @@ struct page {
 	struct hash_elem hash_elem; // hash element for supplemental page table
 	struct list_elem frame_elem; // list element for frame list
 	
-	char __unused[49];
-	
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
 	union {

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -51,6 +51,7 @@ struct page {
 	/* Your implementation */
 
 	struct hash_elem hash_elem; // hash element for supplemental page table
+	struct list_elem frame_elem; // list element for frame list
 	
 	char __unused[49];
 	
@@ -69,9 +70,10 @@ struct page {
 /* The representation of "frame" */
 struct frame {
 	void *kva; // kernel virtual address
-	struct page *page; // back reference for page
+	// struct page *page; // back reference for page
+	struct list page_list; // list element for page list
 	uint32_t ref_cnt; // reference count
-	struct list_elem elem // frame table element
+	struct list_elem elem; // frame table element
 };
 
 /* The function table for page operations.

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -70,6 +70,7 @@ struct page {
 struct frame {
 	void *kva; // kernel virtual address
 	struct page *page; // back reference for page
+	uint32_t ref_cnt; // reference count
 	struct list_elem elem // frame table element
 };
 

--- a/tests/vm/child-linear.c
+++ b/tests/vm/child-linear.c
@@ -20,6 +20,7 @@ main (int argc, char *argv[])
   size_t i;
 
   /* Encrypt zeros. */
+  // printf("[*] encrypting zeros\n");
   arc4_init (&arc4, key, strlen (key));
   arc4_crypt (&arc4, buf, SIZE);
 

--- a/tests/vm/cow/cow-simple.c
+++ b/tests/vm/cow/cow-simple.c
@@ -10,7 +10,7 @@
 
 #define CHUNK_SIZE (128 * 1024)
 
-static char buffer[2048];
+static char buffer[CHUNK_SIZE + 1];
 
 void
 test_main (void)
@@ -49,7 +49,7 @@ test_main (void)
 	
 	CHECK ((handle = open("sample.txt")) > 1, "open \"sample.txt\"");
 	
-	CHECK (read(handle, buffer, 2048) > 1, "부모: read \"sample.txt\"");
+	CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "부모: read \"sample.txt\"");
 	printf("[*] parent read data: %s\n", buffer);
 
 	pa_parent = get_phys_addr((void *) buffer);
@@ -65,7 +65,7 @@ test_main (void)
           "two phys addrs should be the same. (%p), (%p)", pa_parent, pa_child);
 
 		seek(handle, 0);
-    CHECK (read(handle, buffer, 2048) > 1, "자식: read \"sample.txt\" 읽는다.");
+    CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "자식: read \"sample.txt\" 읽는다.");
 		
 		printf("read bytes: %s\n", buffer);
 		

--- a/tests/vm/cow/cow-simple.c
+++ b/tests/vm/cow/cow-simple.c
@@ -18,66 +18,65 @@ test_main (void)
 	pid_t child;
 	void *pa_parent;
 	void *pa_child;
-	// char *buf = "Lorem ipsum";
-	char buffer_local[2048];
+	char *buf = "Lorem ipsum";
 
-	// CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
-	// pa_parent = get_phys_addr((void*)large);
+	CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
+	pa_parent = get_phys_addr((void*)large);
 
-	// child = fork ("child");
-	// if (child == 0) {
-	// 	CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
+	child = fork ("child");
+	if (child == 0) {
+		CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
 
-	// 	pa_child = get_phys_addr((void*)large);
-	// 	CHECK (pa_parent == pa_child, "two phys addrs should be the same.");
+		pa_child = get_phys_addr((void*)large);
+		CHECK (pa_parent == pa_child, "two phys addrs should be the same.");
 
-	// 	large[0] = '@';
-	// 	CHECK (memcmp (buf, large, strlen (buf)) != 0, "check data change");
+		large[0] = '@';
+		CHECK (memcmp (buf, large, strlen (buf)) != 0, "check data change");
 
-	// 	pa_child = get_phys_addr((void*)large);
-	// 	CHECK (pa_parent != pa_child, "two phys addrs should not be the same.");
-	// 	return;
-	// }
-	// wait (child);
-	// CHECK (pa_parent == get_phys_addr((void*)large), "two phys addrs should be the same.");
-	// CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
+		pa_child = get_phys_addr((void*)large);
+		CHECK (pa_parent != pa_child, "two phys addrs should not be the same.");
+		return;
+	}
+	wait (child);
+	CHECK (pa_parent == get_phys_addr((void*)large), "two phys addrs should be the same.");
+	CHECK (memcmp (buf, large, strlen (buf)) == 0, "check data consistency");
 	
 	/// Child Read
-	printf("\n[*] Child Read\n\n");
+	// printf("\n[*] Child Read\n\n");
 	
-	int handle;
+	// int handle;
 	
-	CHECK ((handle = open("sample.txt")) > 1, "open \"sample.txt\"");
+	// CHECK ((handle = open("sample.txt")) > 1, "open \"sample.txt\"");
 	
-	CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "부모: read \"sample.txt\"");
-	printf("[*] parent read data: %s\n", buffer);
+	// CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "부모: read \"sample.txt\"");
+	// printf("[*] parent read data: %s\n", buffer);
 
-	pa_parent = get_phys_addr((void *) buffer);
+	// pa_parent = get_phys_addr((void *) buffer);
 	
-	printf("[*] 🍴 포크하기 직전!!\n");
+	// printf("[*] 🍴 포크하기 직전!!\n");
 	
-	child = fork("child");
-	if (child == 0) {
-		// child process
-		printf("[*] child process\n");
-		pa_child = get_phys_addr((void *) buffer);
-    CHECK(pa_parent == pa_child,
-          "two phys addrs should be the same. (%p), (%p)", pa_parent, pa_child);
+	// child = fork("child");
+	// if (child == 0) {
+	// 	// child process
+	// 	printf("[*] child process\n");
+	// 	pa_child = get_phys_addr((void *) buffer);
+  //   CHECK(pa_parent == pa_child,
+  //         "two phys addrs should be the same. (%p), (%p)", pa_parent, pa_child);
 
-		seek(handle, 0);
-    CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "자식: read \"sample.txt\" 읽는다.");
+	// 	seek(handle, 0);
+  //   CHECK (read(handle, buffer, CHUNK_SIZE) > 1, "자식: read \"sample.txt\" 읽는다.");
 		
-		printf("read bytes: %s\n", buffer);
+	// 	printf("read bytes: %s\n", buffer);
 		
-		pa_child = get_phys_addr((void *) buffer);
-		CHECK (pa_parent != pa_child, "two phys addrs should not be the same. (%p), (%p)", pa_parent, pa_child);
-		return;
-	} else {
-		// parent process
-		wait (child);
-		printf("[*] parent process end\n");
-		CHECK (pa_parent == get_phys_addr((void *) buffer), "two phys addrs should be the same.");
-	}
+	// 	pa_child = get_phys_addr((void *) buffer);
+	// 	CHECK (pa_parent != pa_child, "two phys addrs should not be the same. (%p), (%p)", pa_parent, pa_child);
+	// 	return;
+	// } else {
+	// 	// parent process
+	// 	wait (child);
+	// 	printf("[*] parent process end\n");
+	// 	CHECK (pa_parent == get_phys_addr((void *) buffer), "two phys addrs should be the same.");
+	// }
 
 	return;
 }

--- a/threads/start.S
+++ b/threads/start.S
@@ -2,6 +2,7 @@
 #define LONG_MODE (1 << 29)
 #define CR0_PE 0x00000001
 #define CR0_PG (1 << 31)
+#define CR0_WP 0x00010000      /* Write-Protect enable in kernel mode. */
 #define CR4_PAE 0x20
 #define PTE_P 0x1
 #define PTE_W 0x2

--- a/threads/start.S
+++ b/threads/start.S
@@ -98,7 +98,7 @@ fill_pdes:
 
 #### Enable paging
 	mov %cr0, %eax
-	or $(CR0_PE|CR0_PG), %eax
+	or $(CR0_PE|CR0_PG|CR0_WP), %eax
 	mov %eax, %cr0
 
 #### Jump to the long mode

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -830,8 +830,8 @@ static bool lazy_load_segment(struct page *page, void *aux) {
   
   lock_acquire(inode_get_lock(file_get_inode(file)));
 
-  // code segment registration
-  pml4_set_page(t->pml4, page->va, page->frame->kva, writable);
+  // 커널의 세그먼트 적재 시작, writeable true
+  pml4_set_page(t->pml4, page->va, page->frame->kva, true);
 
   /* copy of load_segment when USERPROG */
   ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
@@ -854,6 +854,10 @@ static bool lazy_load_segment(struct page *page, void *aux) {
   free(aux); // 인자 (malloc) free 수행
 
   lock_release(inode_get_lock(file_get_inode(file)));
+
+  // 커널의 세그먼트 적재완료, writeable 원복
+  pml4_set_page(t->pml4, page->va, page->frame->kva, writable);
+
   return true;
 }
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -253,7 +253,7 @@ int process_exec(void *f_name) {
   char *file_name = f_name;
   bool success;
   int i;
-  char **argv = (char *)malloc (sizeof(char) * 128);
+  char **argv = (char **)palloc_get_page(0);
   char *token, *save_ptr; // token화 하기 위한 변수
   int argc = 0;  // argument 개수
 
@@ -283,6 +283,7 @@ int process_exec(void *f_name) {
   /* 유저스택에 인자 추가 */
   argument_stack(argc, argv, &_if);
   palloc_free_page(file_name);
+  palloc_free_page(argv);
   
   /* 프로세스 전환하여 실행 */
   do_iret(&_if);
@@ -429,7 +430,7 @@ void process_activate(struct thread *next) {
  * @brief 초기화된 유저 스택공간에 직접 인자를 추가한다.
  */
 void argument_stack(int argc, char **argv, struct intr_frame *if_) {
-  char *argv_addr[128];
+  char *argv_addr[ARGS_LEN];
 
   for (int i = argc - 1; i >= 0; i--) {
     int argv_len = strlen(argv[i]);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -311,6 +311,10 @@ int read(int fd, void *buffer, unsigned size) {
   check_address(buffer);
   uint8_t *buf = buffer;
   off_t read_count;
+  
+  if (size == 0) {
+    return 0;
+  }
 
   // check buffer address
   struct page *p = spt_find_page(&thread_current()->spt, pg_round_down(buffer));
@@ -318,7 +322,7 @@ int read(int fd, void *buffer, unsigned size) {
     exit(-1);
   }
   
-  printf("[*] in syscall read, p->frame->kva = %p\n", p->frame->kva);
+  // printf("[*] in syscall read, p->frame->kva = %p\n", p->frame->kva);
 
   if (fd == STDIN_FILENO) {  // STDIN일 때
     char key;
@@ -339,6 +343,7 @@ int read(int fd, void *buffer, unsigned size) {
 
     // exclusive read & write
     // lock_acquire(inode_get_lock(file_get_inode(filep))); 
+    *((char *) buffer) = '@'; // try to read to check if page fault occurs
     filesys_lock_acquire();
     read_count = file_read(filep, buffer, size);
     // lock_release(inode_get_lock(file_get_inode(filep)));

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -455,7 +455,7 @@ static bool lazy_load_file(struct page *page, void *aux) {
   size_t connected_page_idx = hand_in->connected_page_idx;
 
   // code segment registration
-  pml4_set_page(thread_current()->pml4, page->va, page->frame->kva, writable);
+  pml4_set_page(thread_current()->pml4, page->va, page->frame->kva, true);
 
   /* copy of load_segment when USERPROG */
   ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
@@ -476,6 +476,9 @@ static bool lazy_load_file(struct page *page, void *aux) {
   memset(upage + read_bytes, 0, zero_bytes);
 
   free(aux); // 인자 (malloc) free 수행
+
+  // code segment 원복
+  pml4_set_page(thread_current()->pml4, page->va, page->frame->kva, writable);
   
   // set not dirty: 파일 내용을 복사하면서 dirty로 체크됨.
   // 이를 해제해두면 memeory에 데이터가 쓸때 dirty가 체크되므로 수정여부를 판단 가능

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -309,7 +309,6 @@ struct file *fd_to_file(int fd) {
  */
 int read(int fd, void *buffer, unsigned size) {
   check_address(buffer);
-
   uint8_t *buf = buffer;
   off_t read_count;
 
@@ -318,6 +317,8 @@ int read(int fd, void *buffer, unsigned size) {
   if (p == NULL || (p->writable == false)) {
     exit(-1);
   }
+  
+  printf("[*] in syscall read, p->frame->kva = %p\n", p->frame->kva);
 
   if (fd == STDIN_FILENO) {  // STDIN일 때
     char key;

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -104,12 +104,17 @@ anon_swap_out (struct page *page) {
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
 static void
 anon_destroy (struct page *page) {
+  if (page->frame == NULL) {
+    return;
+  }
+
 	filesys_lock_acquire();
 	struct anon_page *anon_page = &page->anon;
-	if (page->frame != NULL) {
-    // frame을 삭제하지 않고 frame table에 놔둬서 다른 page가 사용할 수 있도록 한다.
-    page->frame->page = NULL;
-    page->frame = NULL;
-	}
+  // frame을 삭제하지 않고 frame table에 놔둬서 다른 page가 사용할 수 있도록 한다.
+  page->frame->ref_cnt -= 1;
+  page->frame->page = NULL;
+  page->frame = NULL;
 	filesys_lock_release();
+
+  pml4_clear_page(thread_current()->pml4, page->va);
 }

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -98,7 +98,7 @@ anon_swap_out (struct page *page) {
   }
 	filesys_lock_release();
 
-  pml4_clear_page(thread_current()->pml4, page->va);
+  return true;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
@@ -111,10 +111,11 @@ anon_destroy (struct page *page) {
 	filesys_lock_acquire();
 	struct anon_page *anon_page = &page->anon;
   // frame을 삭제하지 않고 frame table에 놔둬서 다른 page가 사용할 수 있도록 한다.
+	filesys_lock_release();
+
+  // unlink frame을 직접 해주어야 한다.
+  pml4_clear_page(thread_current()->pml4, page->va);
   page->frame->ref_cnt -= 1;
   page->frame->page = NULL;
   page->frame = NULL;
-	filesys_lock_release();
-
-  pml4_clear_page(thread_current()->pml4, page->va);
 }

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -73,8 +73,7 @@ anon_swap_in (struct page *page, void *kva) {
   anon_page->area = -1;
 	filesys_lock_release();
 
-  // thread_current의 pml4에 할당	
-	pml4_set_page(thread_current()->pml4, page->va, kva, page->writable);
+  return true;
 }
 
 /* Swap out the page by writing contents to the swap disk. */

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -59,7 +59,7 @@ static bool
 anon_swap_in (struct page *page, void *kva) {
 	struct anon_page *anon_page = &page->anon;
 	if (anon_page->area == -1 || page->frame == NULL) {
-    printf("[*] swap_in failed!: %p\n", page->va);
+    // printf("[*] swap_in failed!: %p\n", page->va);
 		return false;
 	}
 
@@ -115,6 +115,6 @@ anon_destroy (struct page *page) {
   // unlink frame을 직접 해주어야 한다.
   pml4_clear_page(thread_current()->pml4, page->va);
   page->frame->ref_cnt -= 1;
-  page->frame->page = NULL;
+  list_remove(&page->frame_elem);
   page->frame = NULL;
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -58,13 +58,11 @@ file_backed_swap_in (struct page *page, void *kva) {
 	}
 	memset((char *)kva + file_page->read_bytes, 0, file_page->zero_bytes);
 
-	pml4_set_page(thread_current()->pml4, page->va, page->frame->kva,
-			page->file.writable);
 	success = true;
 
 	done:
-		filesys_lock_release();
 		lock_release(inode_get_lock(file_get_inode(file_page->file)));
+		filesys_lock_release();
 		return success;
 }
 

--- a/vm/file.c
+++ b/vm/file.c
@@ -88,7 +88,6 @@ file_backed_swap_out (struct page *page) {
 	lock_release(inode_get_lock(file_get_inode(file_page->file)));
 	filesys_lock_release();
 
-	pml4_clear_page(thread_current()->pml4, page->va);
 	return true;
 }
 
@@ -128,7 +127,9 @@ file_backed_destroy (struct page *page) {
 		// filesys_lock_release();
 	}
 
+	// unlink frame을 직접 해주어야 한다.
 	pml4_clear_page(cur->pml4, page->va);
+	page->frame->ref_cnt -= 1;
 	page->frame->page = NULL;
 	page->frame = NULL;
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -128,7 +128,7 @@ file_backed_destroy (struct page *page) {
 	// unlink frame을 직접 해주어야 한다.
 	pml4_clear_page(cur->pml4, page->va);
 	page->frame->ref_cnt -= 1;
-	page->frame->page = NULL;
+	list_remove(&page->frame_elem);
 	page->frame = NULL;
 }
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -347,7 +347,6 @@ vm_do_claim_page (struct page *page) {
 
   bool success = swap_in (page, frame->kva);
   if (success) {
-    pml4_clear_page(thread_current()->pml4, page->va);
     pml4_set_page(thread_current()->pml4, page->va, frame->kva, false); // cow
   }
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -142,13 +142,6 @@ static bool frame_less (struct list_elem *a, struct list_elem *b) {
   return frame_a->ref_cnt < frame_b->ref_cnt;
 }
 
-static bool frame_less (struct list_elem *a, struct list_elem *b) {
-  struct frame *frame_a = list_entry(a, struct frame, elem);
-  struct frame *frame_b = list_entry(b, struct frame, elem);
-
-  return frame_a->ref_cnt < frame_b->ref_cnt;
-}
-
 /* Get the struct frame, that will be evicted. */
 static struct frame *
 vm_get_victim (void) {

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -156,9 +156,12 @@ vm_get_victim (void) {
   // e = list_pop_front(&frame_table);
   // list_push_back(&frame_table, e);
 
-  // policy: ref_cnt가 가장 작은 frame을 victim으로 선정
-  { 
-    // list_min 확장
+  {
+    /**
+     * @brief list_min extension
+     * @policy: ref_cnt가 가장 작은 frame을 victim으로 선정. 이때, ref_cnt가
+     * 1보다 작다면 빠르게 반복문을 나간다.
+     */
     if (min != list_end(list)) {
       struct list_elem *e;
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -135,6 +135,13 @@ spt_remove_page (struct supplemental_page_table *spt, struct page *page) {
 	vm_dealloc_page (page);
 }
 
+static bool frame_less (struct list_elem *a, struct list_elem *b) {
+  struct frame *frame_a = list_entry(a, struct frame, elem);
+  struct frame *frame_b = list_entry(b, struct frame, elem);
+
+  return frame_a->ref_cnt < frame_b->ref_cnt;
+}
+
 /* Get the struct frame, that will be evicted. */
 static struct frame *
 vm_get_victim (void) {
@@ -142,10 +149,11 @@ vm_get_victim (void) {
   if (list_empty(&frame_table)) {
     return NULL;
   }
-  // policy: FIFO
-  struct list_elem *victim_elem = list_pop_front(&frame_table);
-  list_push_back(&frame_table, victim_elem);
-	victim = list_entry(victim_elem, struct frame, elem);
+  // policy: ref_cnt가 가장 작은 frame을 victim으로 선정
+  struct list_elem *e = list_min(&frame_table, frame_less, NULL);
+  victim = list_entry(e, struct frame, elem);
+
+  ASSERT (victim->ref_cnt <= 1);
 
 	return victim;
 }
@@ -187,6 +195,7 @@ vm_get_frame (void) {
   struct frame *frame = malloc(sizeof(struct frame));
   frame->kva = kva;
   frame->page = NULL;
+  frame->ref_cnt = 0;
 
   list_push_back(&frame_table, &frame->elem); // 생성한 frame 관리
 
@@ -290,6 +299,7 @@ vm_do_claim_page (struct page *page) {
 	/* Set links */
 	frame->page = page;
 	page->frame = frame;
+  frame->ref_cnt += 1;
 
   // anonymous 는 0으로 채워줘야 한다.
   if (page_get_type(page) == VM_ANON) {

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -194,10 +194,6 @@ vm_evict_frame (void) {
     return NULL; // TODO kernel panic?
   }
   
-  if (list_empty (&victim->page_list)) {
-    return victim;
-  }
-
   // page와 frame을 분리
   while (!list_empty (&victim->page_list)) {
     // swap out page element and unlink it

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -284,8 +284,10 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
       vm_stack_growth(upage_entry);
       struct page *_p = spt_find_page(spt, upage_entry);
       if (_p != NULL) {
-        pml4_clear_page(thread_current()->pml4, _p->va);
+        // pml4_clear_page(thread_current()->pml4, _p->va);
         pml4_set_page(thread_current()->pml4, _p->va, _p->frame->kva, false); // cow
+      } else {
+        return false;
       }
 
       return true;


### PR DESCRIPTION
## TL;DR

- 단순한 COW (`ref_cnt`, pte write protection bit를 0으로) 구현 및 단순한 eviction policy (프레임 참조카운트가 1인 프레임만 victim으로 선정) 구현
- #79 참조

## ai 요약

시간의 역순으로 읽어주세요

1. 커밋 46219a6783:
   - 브랜치를 병합하는 작업을 수행하였습니다.
2. 커밋 6e09e3383f:
   - 불필요한 코드를 삭제하였습니다.
3. 커밋 047eee11ba:
   - get_victim에 대한 문서를 추가하였습니다.
4. 커밋 ab791384f2:
   - 주석을 수정하고, 코드 디버깅 관련 프린트문을 제거하였습니다.
   - get_victim 함수의 로직을 변경하였습니다.
5. 커밋 86cbe91407:
   - 이슈 #65를 닫았습니다.
6. 커밋 0841462723:
   - 프레임과 페이지 간의 관계를 수정하였습니다.
   - swap in 및 swap out 상황을 수정하였습니다.
7. 커밋 0951710ac0:
   - 파일을 읽기 전에 버퍼에 가짜 쓰기를 추가하였습니다.
8. 커밋 f3af7075c0:
   - 커널에 CR0_WP 플래그를 추가하였습니다.
9. 커밋 c81039b2b2:
   - CR0_WP 플래그를 추가하였습니다.
10. 커밋 f5a8b5a089:
    - try_handle_fault에서 spt_find_page가 NULL일 경우 false를 반환하도록 수정하였습니다.
11. 커밋 5cfb650f34:
    - swap_out을 수정하였습니다.
12. 커밋 ed599106b9:
    - handle_wp를 수정하여 ref_cnt에 따라 로직을 변경하였습니다.
13. 커밋 5aa5c6f73c:
    - 중복을 제거하였습니다.
14. 커밋 a1077b48bd:
    - 브랜치를 병합하였습니다.
15. 커밋 df3dcbe14d:
    - Copy-On-Write(COW)를 성공하고, ref_cnt를 도입하였으며, swap_out의 역할을 분리하였습니다.
16. 커밋 6f4fc16211:
    - anon_page 삭제 시 프레임 존재 여부에 따라 로직을 추가하였습니다.
17. 커밋 6f09a3a0eb:
    - evict_frame 정책을 변경하였습니다.
18. 커밋 10f419513f:
    - evict_frame 정책을 변경하였습니다.